### PR TITLE
Handle lazy initialized DataType.types field properly

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -154,10 +154,10 @@ function get_module(c::Pkg.Types.Context, m::Module)
             elseif t isa DataType
                 if t.abstract || t.isbitstype
                     out.vals[String(n)] = DataTypeStore(string.(p), [], [], [], _getdoc(x))
-                elseif isdefined(t, :types) && !isempty(t.types) && !Base.isvatuple(t)
+                elseif !isempty(Base.datatype_fieldtypes(t)) && !Base.isvatuple(t)
                     out.vals[String(n)] = DataTypeStore(string.(p),
                                                      collect(string.(fieldnames(t))),
-                                                     TypeRef.(collect(t.types)),
+                                                     TypeRef.(collect(Base.datatype_fieldtypes(t))),
                                                      read_methods(x),
                                                      _getdoc(x))
                 else


### PR DESCRIPTION
Commit a8c8377cc43f024b0c02200f1cd7e0c1ab83caca to the main julia repo made the DataType.types field lazily initialized, so accessing it directly is not correct.  Base.datatype_fieldtypes() will populate and get this field properly.  Simply checking for whether :types is defined is not sufficient.
