### PR TITLE
Fix world age bug

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -99,7 +99,7 @@ function read_methods(x)
         if path === nothing
             path = ""
         end
-        args = Base.arg_decl_parts(m)[2][2:end]
+        args = Base.invokelatest(Base.arg_decl_parts, m)[2][2:end]
         if isdefined(ms.mt, :kwsorter)
             kws = kwarg_decl(m, typeof(ms.mt.kwsorter))
             for kw in kws


### PR DESCRIPTION
We've had a long standing bug when an environment contains the MOI package (https://github.com/julia-vscode/SymbolServer.jl/issues/52). Hopefully this fixes the problem for good. this also came in via crash reporting, and I was able to reproduce the error, and this fix seemed to get rid of it.