### PR TITLE
Remove precompile step

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -37,9 +37,9 @@ mutable struct SymbolServerProcess
         stderr_for_client_process = VERSION < v"1.1.0" ? nothing : IOBuffer()
 
         p = if environment === nothing
-            open(pipeline(Cmd(`$jl_cmd --startup-file=no --history-file=no $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+            open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
         else
-            open(pipeline(Cmd(`$jl_cmd --startup-file=no --history-file=no --project=$environment $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+            open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no --project=$environment $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
         end
         ssp = new(p, nothing, deepcopy(stdlibs), stderr_for_client_process, Set{UUID}(), UUID[])
         get_context(ssp)


### PR DESCRIPTION
This is a trade-off decision we need to make.

Without this PR I get the following timings:

Index an environment where nothing is precompiled: 416 seconds
Index an environment where everything is precompiled: 196 seconds

With this PR:

Index an environment: 267 seconds

So with this PR we make the case where the precompile cache is out-of-date faster, but we make the situation where the precompile cache is up-to-date slower.

Another benefit of this PR is that we don't create precompile files, so in some sense it is less intrusive than our previous story.

Not sure whether we should do this, to be honest :) Probably yes, because it improves the worst case scenario?

Thanks @pfitzseb for suggesting this.