### PR TITLE
Rework API for async use

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Documentation for working with Julia environments is available [here](https://gi
 ## API
 
 ```julia
-SymbolServerProcess(path_to_env)
+SymbolServerInstance(path_to_env)
 ```
 Launches a server process (with given enviroment) and retrieves the active context. This client side process (this) contains a depot of retrieved packages.
 
 ```julia
-change_env(ssp::SymbolServerProcess, env_path::String)
+change_env(ssp::SymbolServerInstance, env_path::String)
 ```
 Activates a new environment on the server. The new active context must then be retrieved separately.
 
 ```julia
-get_context(ssp::SymbolServerProcess)
+get_context(ssp::SymbolServerInstance)
 ```
 Retrieves the active context (environment) from the server.
 

--- a/README.md
+++ b/README.md
@@ -12,29 +12,14 @@ Documentation for working with Julia environments is available [here](https://gi
 ## API
 
 ```julia
-SymbolServerInstance(path_to_env)
+SymbolServerInstance(path_to_depot)
 ```
-Launches a server process (with given enviroment) and retrieves the active context. This client side process (this) contains a depot of retrieved packages.
 
-```julia
-change_env(ssp::SymbolServerInstance, env_path::String)
-```
-Activates a new environment on the server. The new active context must then be retrieved separately.
-
-```julia
-get_context(ssp::SymbolServerInstance)
-```
-Retrieves the active context (environment) from the server.
+Creates a new symbol server instance that works on a given Julia depot. This symbol server instance can be long lived, i.e. one can re-use it for different environments etc.
 
 
 ```julia
-load_manifest_packages(ssp)
-load_project_packages(ssp)
+getstore(ssi::SymbolServerInstance, environment_path::AbstractString, result_channel)
 ```
-Load all packages from the current active environments manifest or project into the client
-side depot.
 
-
-
-
-
+Initiates async loading of symbols for the environment in `environment_path`. This function is non blocking, i.e. it returns immediately before the actual work is finished. `result_channel` must be a `Channel`. The new store, once loaded, will be pushed to that channel. One can call this function repeatedly, even before a previous call has returned results. In that case, the previous load attemp is canceled.

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -17,8 +17,6 @@ mutable struct SymbolServerInstance
     depot_path::String
 
     function SymbolServerInstance(depot_path::String)
-        !ispath(depot_path) && error("Must specify a depot path.")
-
         return new(nothing, nothing, depot_path)
     end
 end
@@ -30,7 +28,12 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, r
     server_script = joinpath(@__DIR__, "server.jl")
 
     env_to_use = copy(ENV)
-    env_to_use["JULIA_DEPOT_PATH"] = ssi.depot_path
+
+    if ssi.depot_path==""
+        delete!(env_to_use, "JULIA_DEPOT_PATH")
+    else
+        env_to_use["JULIA_DEPOT_PATH"] = ssi.depot_path
+    end
 
     # stderr_for_client_process = VERSION < v"1.1.0" ? nothing : IOBuffer()    
     stderr_for_client_process = nothing

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -4,11 +4,8 @@ export SymbolServerInstance, getstore
 
 using Serialization, Pkg, SHA
 using Base: UUID
-@static if VERSION < v"1.1"
-    const PackageEntry = Vector{Dict{String,Any}}
-else
-    using Pkg.Types: PackageEntry
-end
+
+include("utils.jl")
 include("symbols.jl")
 
 mutable struct SymbolServerInstance
@@ -128,8 +125,6 @@ function clear_disc_store()
         end
     end
 end
-
-include("utils.jl")
 
 const stdlibs = load_core()
 

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -70,9 +70,10 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, r
 end
 
 function load_project_packages_into_store!(ssi::SymbolServerInstance, environment_path, store)
-    # TODO Detect Project.toml and JuliaProject.toml
-    project = Pkg.API.read_project(joinpath(environment_path, "Project.toml"))
-    # TODO Detect Manifest.toml and JuliaManifest.toml
+    project_filename = isfile(joinpath(environment_path, "JuliaProject.toml")) ? joinpath(environment_path, "JuliaProject.toml") : joinpath(environment_path, "Project.toml")
+    project = Pkg.API.read_project(project_filename)
+
+    manifest_filename = isfile(joinpath(environment_path, "JuliaManifest.toml")) ? joinpath(environment_path, "JuliaManifest.toml") : joinpath(environment_path, "Manifest.toml")
     manifest = Pkg.API.read_manifest(joinpath(environment_path, "Manifest.toml"))
 
     for uuid in values(deps(project))

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -5,8 +5,8 @@ export SymbolServerInstance, getstore
 using Serialization, Pkg, SHA
 using Base: UUID
 
-include("utils.jl")
 include("symbols.jl")
+include("utils.jl")
 
 mutable struct SymbolServerInstance
     process::Union{Nothing,Base.Process}

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -1,6 +1,6 @@
 module SymbolServer
 
-export SymbolServerInstance, change_env, load_manifest_packages, load_project_packages, get_context, getstore
+export SymbolServerInstance, getstore
 
 using Serialization, Pkg, SHA
 using Base: UUID

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -88,7 +88,7 @@ Tries to load the on-disc stored cache for a package (uuid). Attempts to generat
 """
 function load_package_from_cache_into_store!(ssi::SymbolServerInstance, uuid::UUID, manifest, store)
     storedir = abspath(joinpath(@__DIR__, "..", "store"))
-    cache_path = joinpath(storedir, string(uuid, ".jstore"))
+    cache_path = joinpath(storedir, get_filename_from_name(manifest, uuid))
 
     if !isinmanifest(manifest, uuid)
         @info "Tried to load $uuid but failed to find it in the manifest."

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -32,6 +32,7 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, r
         env_to_use["JULIA_DEPOT_PATH"] = ssi.depot_path
     end
 
+    # TODO Put this back in once we have crash reporting back up
     # stderr_for_client_process = VERSION < v"1.1.0" ? nothing : IOBuffer()    
     stderr_for_client_process = nothing
 
@@ -39,7 +40,9 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, r
         kill(ssi.process)
     end
 
-    p = open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no --project=$environment_path $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+    use_code_coverage = Base.JLOptions().code_coverage
+
+    p = open(pipeline(Cmd(`$jl_cmd --code-coverage=$(use_code_coverage==0 ? "none" : "user") --startup-file=no --compiled-modules=no --history-file=no --project=$environment_path $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
     ssi.process = p
     ssi.process_stderr = stderr_for_client_process
 

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -1,7 +1,6 @@
 module SymbolServer
-module LoadingBay
-end
-export SymbolServerProcess, change_env, load_manifest_packages, load_project_packages, get_context, getstore
+
+export SymbolServerInstance, change_env, load_manifest_packages, load_project_packages, get_context, getstore
 
 using Serialization, Pkg, SHA
 using Base: UUID
@@ -12,247 +11,109 @@ else
 end
 include("symbols.jl")
 
-mutable struct SymbolServerProcess
-    process::Base.Process
-    context::Union{Nothing,Pkg.Types.Context}
-    depot::Dict{String,ModuleStore}
+mutable struct SymbolServerInstance
+    process::Union{Nothing,Base.Process}
     process_stderr::Union{IOBuffer,Nothing}
+    depot_path::String
 
-    caching_packages::Set{UUID}
-    newly_cached_packages::Vector{UUID}
+    function SymbolServerInstance(depot_path::String)
+        !ispath(depot_path) && error("Must specify a depot path.")
 
-    function SymbolServerProcess(;environment = nothing, depot = nothing)
-        jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
-        server_script = joinpath(@__DIR__, "server.jl")
+        return new(nothing, nothing, depot_path)
+    end
+end
 
-        env_to_use = copy(ENV)
-        if depot !== nothing
-            if depot == ""
-                delete!(env_to_use, "JULIA_DEPOT_PATH")
-            else
-                env_to_use["JULIA_DEPOT_PATH"] = depot
-            end
-        end
+function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, result_channel)
+    !ispath(environment_path) && error("Must specify an environment path.")
 
-        stderr_for_client_process = VERSION < v"1.1.0" ? nothing : IOBuffer()
+    jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
+    server_script = joinpath(@__DIR__, "server.jl")
 
-        p = if environment === nothing
-            open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+    env_to_use = copy(ENV)
+    env_to_use["JULIA_DEPOT_PATH"] = ssi.depot_path
+
+    # stderr_for_client_process = VERSION < v"1.1.0" ? nothing : IOBuffer()    
+    stderr_for_client_process = nothing
+
+    if ssi.process!==nothing
+        kill(ssi.process)
+    end
+
+    p = open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no --project=$environment_path $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+    ssi.process = p
+    ssi.process_stderr = stderr_for_client_process
+
+    @async begin
+        @info "Waiting for symbol server to finish"
+        if success(p)
+            @info "Symbol server finished."
+
+            # Now we create a new symbol store and load everything into that
+            # from disc
+            new_store = deepcopy(stdlibs)
+            load_project_packages_into_store!(ssi, environment_path, new_store)
+
+            @info "Push store to channel."
+            # Finally, we push the new store into the results channel
+            # Clients can pick it up from there
+            push!(result_channel, new_store)
+            @info "getstore is finished."
         else
-            open(pipeline(Cmd(`$jl_cmd --startup-file=no --compiled-modules=no --history-file=no --project=$environment $server_script`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
-        end
-        ssp = new(p, nothing, deepcopy(stdlibs), stderr_for_client_process, Set{UUID}(), UUID[])
-        get_context(ssp)
-        return ssp
-    end
-end
-
-function Base.show(io::IO, ssp::SymbolServerProcess)
-    println(io, "SymbolServerProcess with $(length(ssp.depot)) ($(sum(!isempty(v.vals) for (k, v) in ssp.depot))) packages")
-
-    print(join(sort!([string(isempty(v.vals) ? " ** " : "    ", k) for (k, v) in ssp.depot], lt = (a, b)->a[5:end] < b[5:end]), "\n"))
-end
-
-
-function request(ssp::SymbolServerProcess, message::Symbol, payload)
-    serialize(ssp.process, (message, payload))
-    ret_val = try
-        deserialize(ssp.process)
-    catch err
-        # Only Julia 1.1 and newer support capturing stderr into an IOBuffer
-        if ssp.process_stderr !== nothing
-            stderr_from_client_process = String(take!(ssp.process_stderr))
-
-            complete_error_message = string(sprint(showerror, err), "\n\nstderr from client process:\n\n", stderr_from_client_process)
-
-            error(complete_error_message)
-        else
-            complete_error_message = string(sprint(showerror, err), "\n\nCouldn't capture stderr from client process on julia 1.0.\n\n")
-
-            error(complete_error_message)
+            @info "Symbol server failed."
         end
     end
-
-    !(ret_val isa Tuple{Symbol,<:Any}) && error("Invalid response:\n", ret_val)
-    return ret_val
+        
+    return
 end
 
-"""
-    load_manifest_packages(ssp)
-Load all packages from the current active environments manifest into the client
-side depot.
-"""
-function load_manifest_packages(ssp::SymbolServerProcess)
-    # for uuid in keys(manifest(ssp.context))
-    for pkg in manifest(ssp.context)
-        load_package_cache(ssp, packageuuid(pkg))
-    end
-    update(ssp)
-end
+function load_project_packages_into_store!(ssi::SymbolServerInstance, environment_path, store)
+    # TODO Detect Project.toml and JuliaProject.toml
+    project = Pkg.API.read_project(joinpath(environment_path, "Project.toml"))
+    # TODO Detect Manifest.toml and JuliaManifest.toml
+    manifest = Pkg.API.read_manifest(joinpath(environment_path, "Manifest.toml"))
 
-function load_project_packages(ssp::SymbolServerProcess)
-    for uuid in values(deps(project(ssp.context)))
-        load_package_cache(ssp, uuid)
-    end
-    update(ssp)
-end
-
-function getstore(ssp::SymbolServerProcess)
-    load_project_packages(ssp)
-    return ssp.depot
-end
-
-"""
-    get_context(ssp)
-Retrieves the active context (environment) from the server.
-"""
-function get_context(ssp::SymbolServerProcess)
-    status, payload = request(ssp, :get_context, nothing)
-    if status == :success
-        ssp.context = payload
-        return
-    else
-        error(payload)
-    end
-end
-"""
-    change_env(ssp, env_path)
-Activates a new environment on the server. The new active context must then be retrieved separately.
-"""
-function change_env(ssp::SymbolServerProcess, env_path::String)
-    status, payload = request(ssp, :change_env, env_path)
-    if status == :success
-        return payload
-    else
-        error(payload)
+    for uuid in values(deps(project))
+        load_package_from_cache_into_store!(ssi, uuid, manifest, store)
     end
 end
 
-
 """
-    load_package_cache(ssp::SymbolServerProcess, uuid::UUID)
+    load_package_from_cache_into_store!(ssp::SymbolServerInstance, uuid::UUID, store)
+
 Tries to load the on-disc stored cache for a package (uuid). Attempts to generate (and save to disc) a new cache if the file does not exist or is unopenable.
 """
-function load_package_cache(ssp::SymbolServerProcess, uuid::UUID)
+function load_package_from_cache_into_store!(ssi::SymbolServerInstance, uuid::UUID, manifest, store)
     storedir = abspath(joinpath(@__DIR__, "..", "store"))
     cache_path = joinpath(storedir, string(uuid, ".jstore"))
 
-    if !isinmanifest(ssp.context, uuid)
+    if !isinmanifest(manifest, uuid)
         @info "Tried to load $uuid but failed to find it in the manifest."
         return
     end
 
-    pe = frommanifest(ssp.context, uuid)
-    pe_name = packagename(ssp.context, uuid)
+    pe = frommanifest(manifest, uuid)
+    pe_name = packagename(manifest, uuid)
+
+    haskey(store, pe_name) && return
+
+    @info "Loading $pe_name from cache."
+
     if isfile(cache_path)
         try
-            store = open(cache_path) do io
+            package_data = open(cache_path) do io
                 deserialize(io)
             end
-            if version(pe) != store.ver || (store.ver isa String && endswith(store.ver, "+") && sha_pkg(pe) != store.sha)
-                @info "$pe_name changed, updating cache."
-                cache_package(ssp, uuid)
-                store = open(cache_path) do io
-                    deserialize(io)
-                end
-            end
-            ssp.depot[pe_name] = store.val
+            store[pe_name] = package_data.val
             for dep in deps(pe)
-                load_dependency_cache(ssp, packageuuid(dep))
+                load_package_from_cache_into_store!(ssi, packageuuid(dep), manifest, store)
             end
         catch err
             @info "Tried to load $pe_name but failed to load from disc, re-caching."
-            if err isa UndefVarError && err.var in (:structStore, :abstractStore)
-                @info "Package cache pre-v3.0"
-            end
             rm(cache_path)
-            cache_package(ssp, uuid)
         end
     else
         @info "$(pe_name) not stored on disc"
-        cache_package(ssp, uuid)
     end
-end
-
-function load_dependency_cache(ssp::SymbolServerProcess, uuid::UUID)
-    storedir = abspath(joinpath(@__DIR__, "..", "store"))
-    cache_path = joinpath(storedir, string(uuid, ".jstore"))
-    if !isinmanifest(ssp.context, uuid)
-        @info "Tried to load $uuid cache as a dependency but failed to find it in the manifest."
-        return
-    end
-    pe = frommanifest(ssp.context, uuid)
-    pe_name = packagename(ssp.context, uuid)
-    haskey(ssp.depot, pe_name) && return
-    @info "loading dependency $pe_name"
-    if isfile(cache_path)
-        try
-            store = open(cache_path) do io
-                deserialize(io)
-            end
-            if version(pe) != store.ver || (store.ver isa String && endswith(store.ver, "+") && sha_pkg(pe) != store.sha)
-                @info "Tried to load $pe_name cache as a dependency but failed."
-            end
-            ssp.depot[pe_name] = store.val
-            for dep in deps(pe)
-                load_dependency_cache(ssp, packageuuid(dep))
-            end
-        catch err
-            if err isa UndefVarError && err.var in (:structStore, :abstractStore)
-                @info "Package cache pre-v3.0"
-            end
-            # rm(cache_path)
-            # cache_package(ssp, uuid)
-        end
-    else
-        @info "Tried to load $pe_name cache as a dependency but no file found."
-        # cache_package(ssp, uuid)
-    end
-
-end
-
-load_package_cache(ssp::SymbolServerProcess, uuid::String) = load_package_cache(ssp, UUID(uuid))
-
-function Base.kill(server::SymbolServerProcess)
-    serialize(server.process, (:close, nothing))
-end
-"""
-    cache_package(ssp, uuid::Union{UUID, Vector{UUID}})
-Sends a request to the server to cache a package or collection of packages.
-Requested packages are added to the list `ssp.caching_packages` to prevent the
-sending multiple requests for the same package.
-
-The server returns a list of packages that it has loaded and adds it to
-`ssp.newly_cached_packages`. This list should be used to `update` the client side
-depot `ssp.depot`.
-"""
-cache_package(ssp::SymbolServerProcess, uuid::UUID) = cache_package(ssp, [uuid])
-function cache_package(ssp::SymbolServerProcess, uuid::Vector{UUID})
-    if uuid in ssp.caching_packages
-        return
-    end
-    union!(ssp.caching_packages, uuid)
-    status, payload = request(ssp, :cache_package, string.(uuid))
-    if status == :success
-        for u in uuid
-            delete!(ssp.caching_packages, u)
-        end
-        append!(ssp.newly_cached_packages, UUID.(first(p) for p in payload))
-        return payload
-    else
-        error(payload)
-    end
-end
-
-"""
-    update(ssp)
-Update the client side depot with newly cached packages.
-"""
-function update(ssp::SymbolServerProcess)
-    for uuid in ssp.newly_cached_packages
-        load_package_cache(ssp, uuid)
-    end
-    empty!(ssp.newly_cached_packages)
 end
 
 function clear_disc_store()
@@ -263,6 +124,9 @@ function clear_disc_store()
         end
     end
 end
+
 include("utils.jl")
+
 const stdlibs = load_core()
+
 end # module

--- a/src/server.jl
+++ b/src/server.jl
@@ -40,9 +40,16 @@ for (pk_name, uuid) in toplevel_pkgs
 
     if isfile(cache_path)
         if is_package_deved(Pkg.Types.Context().env.manifest, uuid)
-            # TODO We need to load the cache and check whether it needs
-            # to be re-cached based on the SHA of the actual content
-            @info "Package $pk_name ($uuid) is deved and we don't know whether our cache is out of date."
+            cached_version = open(cache_path) do io
+                deserialize(io)
+            end            
+
+            if sha_pkg(Pkg.Types.Context().env.manifest[uuid]) != cached_version.sha
+                @info "Now recaching package $pk_name ($uuid)"
+                cache_package(server.context, uuid, server.depot)
+            else
+                @info "Package $pk_name ($uuid) is cached."
+            end
         else            
             @info "Package $pk_name ($uuid) is cached."
         end

--- a/src/server.jl
+++ b/src/server.jl
@@ -20,12 +20,6 @@ end
 using Serialization, Pkg, SHA
 using Base: UUID
 
-@static if VERSION < v"1.1"
-    const PackageEntry = Vector{Dict{String,Any}}
-else
-    using Pkg.Types: PackageEntry
-end
-
 include("symbols.jl")
 include("utils.jl")
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,23 @@
 module SymbolServer
 
+# Try to lower the priority of this process so that it doesn't block the
+# user system.
+@static if Sys.iswindows()
+    # Get process handle
+    p_handle = ccall(:GetCurrentProcess, stdcall, Ptr{Cvoid}, ())
+
+    # Set BELOW_NORMAL_PRIORITY_CLASS, this only affects compute stuff
+    ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00004000)
+    ret!=1 && @warn "Something went wrong when setting BELOW_NORMAL_PRIORITY_CLASS."
+
+    # Also set PROCESS_MODE_BACKGROUND_BEGIN, this affects IO (and maybe also CPU?)
+    ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00100000)
+    ret!=1 && @warn "Something went wrong when setting PROCESS_MODE_BACKGROUND_BEGIN."
+else
+    ret = ccall(:nice, Cint, (Cint, ), 1)
+    # We don't check the return value because it doesn't really matter
+end
+
 module LoadingBay
 end
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -2,21 +2,17 @@ module SymbolServer
 
 # Try to lower the priority of this process so that it doesn't block the
 # user system.
-# @static if Sys.iswindows()
-#     # Get process handle
-#     p_handle = ccall(:GetCurrentProcess, stdcall, Ptr{Cvoid}, ())
+@static if Sys.iswindows()
+    # Get process handle
+    p_handle = ccall(:GetCurrentProcess, stdcall, Ptr{Cvoid}, ())
 
-#     # Set BELOW_NORMAL_PRIORITY_CLASS, this only affects compute stuff
-#     ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00004000)
-#     ret!=1 && @warn "Something went wrong when setting BELOW_NORMAL_PRIORITY_CLASS."
-
-#     # Also set PROCESS_MODE_BACKGROUND_BEGIN, this affects IO (and maybe also CPU?)
-#     ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00100000)
-#     ret!=1 && @warn "Something went wrong when setting PROCESS_MODE_BACKGROUND_BEGIN."
-# else
-#     ret = ccall(:nice, Cint, (Cint, ), 1)
-#     # We don't check the return value because it doesn't really matter
-# end
+    # Set BELOW_NORMAL_PRIORITY_CLASS
+    ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00004000)
+    ret!=1 && @warn "Something went wrong when setting BELOW_NORMAL_PRIORITY_CLASS."
+else
+    ret = ccall(:nice, Cint, (Cint, ), 1)
+    # We don't check the return value because it doesn't really matter
+end
 
 module LoadingBay
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,28 +1,21 @@
 module SymbolServer
 
-conn = stdout
-(outRead, outWrite) = redirect_stdout()
-
 module LoadingBay
 end
+
 using Serialization, Pkg, SHA
 using Base: UUID
+
 @static if VERSION < v"1.1"
     const PackageEntry = Vector{Dict{String,Any}}
 else
     using Pkg.Types: PackageEntry
 end
+
 include("symbols.jl")
 include("utils.jl")
 
 server = Server(abspath(joinpath(@__DIR__, "..", "store")), Pkg.Types.Context(), Dict{Any,Any}())
-if Sys.isunix()
-    global const nullfile = "/dev/null"
-elseif Sys.iswindows()
-    global const nullfile = "nul"
-else
-    error("Platform not supported")
-end
 
 function write_cache(uuid, pkg)
     open(joinpath(server.storedir, "$uuid.jstore"), "w") do io
@@ -30,36 +23,23 @@ function write_cache(uuid, pkg)
     end
 end
 
-while true
-    message, payload = deserialize(stdin)
-    if message == :get_context
-        serialize(conn, (:success, server.context))
-    elseif message == :cache_package
-        for uuid in payload
-            cache_package(server.context, UUID(uuid), server.depot)
-        end
-        out = Tuple{String,String,Bool,Bool,Bool}[] # list of saved caches
-        for  (uuid, pkg) in server.depot
-            overwrote = isfile(joinpath(server.storedir, "$(string(uuid)).jstore"))
-            write_cache(uuid, pkg)
+# First get a list of all package UUIds that we want to cache
+toplevel_pkgs = deps(project(Pkg.Types.Context()))
 
-            isloaded = can_access(LoadingBay, Symbol(packagename(server.context, uuid))) isa Module
-            issaved = isfile(joinpath(server.storedir, "$(string(uuid)).jstore"))
-
-            push!(out, (string(uuid), packagename(server.context, uuid), isloaded, isloaded, overwrote))
-        end
-        serialize(conn, (:success, out))
-    elseif message == :change_env
-        Pkg.API.activate(payload)
-        server.context = Pkg.Types.Context()
-        serialize(conn, (:success, nothing))
-    elseif message == :debugmessage
-        out = string(eval(Meta.parse(payload)))
-        serialize(conn, (:success, out))
-    elseif message == :close
-        break
+# Next make sure the cache is up-to-date for all of these
+for (pk_name, uuid) in toplevel_pkgs
+    if isfile(joinpath(server.storedir, "$uuid.jstore"))
+        @info "Package $pk_name ($uuid) is cached."
     else
-        serialize(conn, (:failure, nothing))
+        @info "Now caching package $pk_name ($uuid)"
+        cache_package(server.context, uuid, server.depot)
     end
 end
+
+# Next write all package info to disc
+for  (uuid, pkg) in server.depot
+    @info "Now writing to disc $uuid"
+    write_cache(uuid, pkg)
+end
+
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -2,21 +2,21 @@ module SymbolServer
 
 # Try to lower the priority of this process so that it doesn't block the
 # user system.
-@static if Sys.iswindows()
-    # Get process handle
-    p_handle = ccall(:GetCurrentProcess, stdcall, Ptr{Cvoid}, ())
+# @static if Sys.iswindows()
+#     # Get process handle
+#     p_handle = ccall(:GetCurrentProcess, stdcall, Ptr{Cvoid}, ())
 
-    # Set BELOW_NORMAL_PRIORITY_CLASS, this only affects compute stuff
-    ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00004000)
-    ret!=1 && @warn "Something went wrong when setting BELOW_NORMAL_PRIORITY_CLASS."
+#     # Set BELOW_NORMAL_PRIORITY_CLASS, this only affects compute stuff
+#     ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00004000)
+#     ret!=1 && @warn "Something went wrong when setting BELOW_NORMAL_PRIORITY_CLASS."
 
-    # Also set PROCESS_MODE_BACKGROUND_BEGIN, this affects IO (and maybe also CPU?)
-    ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00100000)
-    ret!=1 && @warn "Something went wrong when setting PROCESS_MODE_BACKGROUND_BEGIN."
-else
-    ret = ccall(:nice, Cint, (Cint, ), 1)
-    # We don't check the return value because it doesn't really matter
-end
+#     # Also set PROCESS_MODE_BACKGROUND_BEGIN, this affects IO (and maybe also CPU?)
+#     ret = ccall(:SetPriorityClass, stdcall, Cint, (Ptr{Cvoid}, Culong), p_handle, 0x00100000)
+#     ret!=1 && @warn "Something went wrong when setting PROCESS_MODE_BACKGROUND_BEGIN."
+# else
+#     ret = ccall(:nice, Cint, (Cint, ), 1)
+#     # We don't check the return value because it doesn't really matter
+# end
 
 module LoadingBay
 end
@@ -35,8 +35,8 @@ include("utils.jl")
 
 server = Server(abspath(joinpath(@__DIR__, "..", "store")), Pkg.Types.Context(), Dict{Any,Any}())
 
-function write_cache(uuid, pkg)
-    open(joinpath(server.storedir, "$uuid.jstore"), "w") do io
+function write_cache(name, pkg)
+    open(joinpath(server.storedir, name), "w") do io
         serialize(io, pkg)
     end
 end
@@ -46,8 +46,16 @@ toplevel_pkgs = deps(project(Pkg.Types.Context()))
 
 # Next make sure the cache is up-to-date for all of these
 for (pk_name, uuid) in toplevel_pkgs
-    if isfile(joinpath(server.storedir, "$uuid.jstore"))
-        @info "Package $pk_name ($uuid) is cached."
+    cache_path = joinpath(server.storedir, get_filename_from_name(Pkg.Types.Context().env.manifest, uuid))
+
+    if isfile(cache_path)
+        if is_package_deved(Pkg.Types.Context().env.manifest, uuid)
+            # TODO We need to load the cache and check whether it needs
+            # to be re-cached based on the SHA of the actual content
+            @info "Package $pk_name ($uuid) is deved and we don't know whether our cache is out of date."
+        else            
+            @info "Package $pk_name ($uuid) is cached."
+        end
     else
         @info "Now caching package $pk_name ($uuid)"
         cache_package(server.context, uuid, server.depot)
@@ -56,8 +64,10 @@ end
 
 # Next write all package info to disc
 for  (uuid, pkg) in server.depot
+    cache_path = joinpath(server.storedir, get_filename_from_name(Pkg.Types.Context().env.manifest, uuid))
+
     @info "Now writing to disc $uuid"
-    write_cache(uuid, pkg)
+    write_cache(cache_path, pkg)
 end
 
 end

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -89,6 +89,24 @@ else
     kwarg_decl = Base.kwarg_decl
 end
 
+function _lookup(tr::PackageRef{N}, depot::Dict{String,ModuleStore}) where N
+    if haskey(depot, tr.name[1])
+        if N == 1
+            return depot[tr.name[1]]
+        else
+            return _lookup(tr, depot[tr.name[1]], 2)
+        end
+    end
+end
+
+function _lookup(tr::PackageRef{N}, m::ModuleStore, i) where N
+    if i < N && haskey(m.vals, tr.name[i])
+        _lookup(tr, m.vals[tr.name[i]], i + 1)
+    elseif i == N && haskey(m.vals, tr.name[i])
+        return m.vals[tr.name[i]]
+    end
+end
+
 function read_methods(x)
     if x isa Core.IntrinsicFunction
         return MethodStore[MethodStore("intrinsic-function", 0, [("args...", "Any")])]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,9 @@
+@static if VERSION < v"1.1"
+    const PackageEntry = Vector{Dict{String,Any}}
+else
+    using Pkg.Types: PackageEntry
+end
+
 """
     manifest(c::Pkg.Types.Context)
 Retrieves the manifest of a Context.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -212,24 +212,6 @@ function sha_pkg(pe::PackageEntry)
     path(pe) isa String && isdir(path(pe)) && isdir(joinpath(path(pe), "src")) ? sha2_256_dir(joinpath(path(pe), "src")) : nothing
 end
 
-function _lookup(tr::PackageRef{N}, depot::Dict{String,ModuleStore}) where N
-    if haskey(depot, tr.name[1])
-        if N == 1
-            return depot[tr.name[1]]
-        else
-            return _lookup(tr, depot[tr.name[1]], 2)
-        end
-    end
-end
-
-function _lookup(tr::PackageRef{N}, m::ModuleStore, i) where N
-    if i < N && haskey(m.vals, tr.name[i])
-        _lookup(tr, m.vals[tr.name[i]], i + 1)
-    elseif i == N && haskey(m.vals, tr.name[i])
-        return m.vals[tr.name[i]]
-    end
-end
-
 function hasfields(@nospecialize t)
     if t isa UnionAll || t isa Union
         t = Base.argument_datatype(t)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,6 +91,7 @@ else
     # const is_stdlib(a,b) = Pkg.Types.is_stdlib(a,b)
     isinmanifest(context::Pkg.Types.Context, module_name::String) = any(p.name == module_name for (u, p) in manifest(context))
     isinmanifest(context::Pkg.Types.Context, uuid::UUID) = haskey(manifest(context), uuid)
+    isinmanifest(manifest::Dict{UUID, PackageEntry}, uuid::UUID) = haskey(manifest, uuid)
 
     isinproject(context::Pkg.Types.Context, package_name::String) = haskey(deps(project(context)), package_name)
     isinproject(context::Pkg.Types.Context, package_uuid::UUID) = any(u == package_uuid for (n, u) in deps(project(context)))
@@ -105,6 +106,7 @@ else
     packageuuid(pkg::Pair{String,UUID}) = last(pkg)
     packageuuid(pkg::Pair{UUID,PackageEntry}) = first(pkg)
     packagename(c::Pkg.Types.Context, uuid::UUID) = manifest(c)[uuid].name
+    packagename(manifest::Dict{UUID, PackageEntry}, uuid::UUID) = manifest[uuid].name
 
     function deps(uuid::UUID, c::Pkg.Types.Context)
         if haskey(manifest(c), uuid)
@@ -119,6 +121,7 @@ else
     path(pe::PackageEntry) = pe.path
     version(pe::PackageEntry) = pe.version
     frommanifest(c::Pkg.Types.Context, uuid) = manifest(c)[uuid]
+    frommanifest(manifest::Dict{UUID, PackageEntry}, uuid) = manifest[uuid]
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -122,6 +122,25 @@ else
     version(pe::PackageEntry) = pe.version
     frommanifest(c::Pkg.Types.Context, uuid) = manifest(c)[uuid]
     frommanifest(manifest::Dict{UUID, PackageEntry}, uuid) = manifest[uuid]
+
+    function get_filename_from_name(manifest, uuid)
+        pkg_info = manifest[uuid]
+
+        name_for_cash_file = if pkg_info.tree_hash!==nothing
+            # We have a normal package, we use the tree hash
+            pkg_info.tree_hash
+        elseif pkg_info.path!==nothing
+            # We have a deved package, we use the hash of the folder name
+            bytes2hex(sha256(pkg_info.path))
+        else
+            # We have a stdlib, we use the uuid
+            string(uuid)
+        end
+
+        return "Julia-$VERSION-$(Sys.ARCH)-$name_for_cash_file.jstore"
+    end
+
+    is_package_deved(manifest, uuid) = manifest[uuid].path!==nothing
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,9 @@ using Base:UUID
 using Test
 
 @testset "SymbolServer" begin
-    server = SymbolServerProcess()
+    server = SymbolServerInstance()
 
-    @test server isa SymbolServerProcess
+    @test server isa SymbolServerInstance
     @test server.context isa Pkg.Types.Context
     SymbolServer.get_context(server)
     @test server.context isa Pkg.Types.Context
@@ -48,7 +48,7 @@ using Test
     end
 
     @testset "Load project packages" begin
-        server = SymbolServerProcess()
+        server = SymbolServerInstance()
         SymbolServer.load_project_packages(server)
         @test all(k in keys(server.depot) for k in ("LibGit2", "Pkg", "SHA", "Serialization"))
         kill(server)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,53 +4,27 @@ using Base:UUID
 using Test
 
 @testset "SymbolServer" begin
-    server = SymbolServerInstance()
 
-    @test server isa SymbolServerInstance
-    @test server.context isa Pkg.Types.Context
-    SymbolServer.get_context(server)
-    @test server.context isa Pkg.Types.Context
-    @test "SymbolServer" in keys(deps(project(server.context)))
-    @test SymbolServer.isinproject(server.context, "SymbolServer")
-    @test SymbolServer.isinmanifest(server.context, "SymbolServer")
+    mktempdir() do path
+        cp(joinpath(@__DIR__, "testenv", "Project.toml"), joinpath(path, "Project.toml"))
+        cp(joinpath(@__DIR__, "testenv", "Manifest.toml"), joinpath(path, "Manifest.toml"))
 
-    @test all(d in keys(deps(project(server.context))) for d in ("LibGit2", "Pkg", "SHA", "Serialization"))
+        jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
+        run(`$jl_cmd --project=$path --startup-file=no -e 'using Pkg; Pkg.instantiate(); pkg"dev --local TableTraits"'`)
 
-    uuid = packageuuid(server.context, "SymbolServer")
-    @test uuid isa UUID
+        ssi = SymbolServerInstance("")
+        results = Channel(Inf)
+        getstore(ssi, path, results)
+        store = take!(results)
 
+        @test length(store) == 6
+        @test haskey(store, "Core")
+        @test haskey(store, "Base")
+        @test haskey(store, "Base64")
+        @test haskey(store, "IteratorInterfaceExtensions")
+        @test haskey(store, "Markdown")
+        @test haskey(store, "TableTraits")
 
-    pe = frommanifest(server.context, uuid)
-    @test pe isa SymbolServer.PackageEntry
-
-
-    @test !isempty(server.depot["Base"].vals)
-    @test !isempty(server.depot["Core"].vals)
-
-    @testset "Cache package on client side" begin
-        depot = Dict{UUID,Package}()
-        ss_m = SymbolServer.cache_package(server.context, uuid, depot)
-        @test any(p->p[2].name == "SymbolServer", depot)
-        @test any(p->p[2].name == "Pkg", depot)
-        @test any(p->p[2].name == "SHA", depot)
-    end
-
-    @testset "Cache package on server side" begin
-        uuid = packageuuid(server.context, "SHA")
-        SymbolServer.cache_package(server, uuid)
-        SymbolServer.update(server)
-        @test "SHA" in keys(server.depot)
-    end
-
-    @testset "Load manifest packages" begin
-        SymbolServer.load_manifest_packages(server)
-        kill(server)
-    end
-
-    @testset "Load project packages" begin
-        server = SymbolServerInstance()
-        SymbolServer.load_project_packages(server)
-        @test all(k in keys(server.depot) for k in ("LibGit2", "Pkg", "SHA", "Serialization"))
-        kill(server)
+        # TODO Test more things that should be present in the store
     end
 end

--- a/test/testenv/Manifest.toml
+++ b/test/testenv/Manifest.toml
@@ -1,0 +1,13 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/test/testenv/Project.toml
+++ b/test/testenv/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"


### PR DESCRIPTION
@ZacLN this is where I am right now.

Still needs new tests, and some more methods in `utils.jl` to make it work on all Julia versions and crash reporting integration.

Fixes https://github.com/julia-vscode/SymbolServer.jl/issues/73. It now uses the tree hash, SAH of the path name or uuid for the cache filename (for normal packages, deved packages and stdlib packages respectively).