### PR TITLE
remove `ref`s from documentation

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -75,7 +75,7 @@ function _getdoc(x)
     # Packages can add methods to Docs.doc, and those can have a bug,
     # and we don't want that to kill the symbol server process
     try
-        return string(Docs.doc(x))
+        return replace(string(Docs.doc(x)), "(@ref)" => "")
     catch err
         @warn "Couldn't retrieve docs."
         return ""


### PR DESCRIPTION
removes `(@ref)` from documentation. I think these are used to help relate documentation objects together but aren't links.
fixes https://github.com/julia-vscode/LanguageServer.jl/issues/264