### PR TITLE
Guard against a Project.toml Manifest.toml mismatch

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -42,7 +42,16 @@ toplevel_pkgs = deps(project(Pkg.Types.Context()))
 
 # Next make sure the cache is up-to-date for all of these
 for (pk_name, uuid) in toplevel_pkgs
-    cache_path = joinpath(server.storedir, get_filename_from_name(Pkg.Types.Context().env.manifest, uuid))
+
+    file_name = get_filename_from_name(Pkg.Types.Context().env.manifest, uuid)
+
+    # We sometimes have UUIDs in the project file that are not in the 
+    # manifest file. That seems like something that shouldn't happen, but
+    # in practice is not under our control. For now, we just skip these
+    # packages
+    file_name===nothing && continue
+
+    cache_path = joinpath(server.storedir, file_name)
 
     if isfile(cache_path)
         if is_package_deved(Pkg.Types.Context().env.manifest, uuid)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,7 +94,10 @@ function isinmanifest end
         return nothing
     end
     function get_filename_from_name(manifest, uuid)
-        pkg_info = first([p[2][1] for p in manifest if get(p[2][1], "uuid", "") == string(uuid)])
+        temp_var = [p[2][1] for p in manifest if get(p[2][1], "uuid", "") == string(uuid)]
+        isempty(temp_var) && return nothing
+
+        pkg_info = first(temp_var)
 
         name_for_cash_file = if get(pkg_info, "git-tree-sha1", nothing)!==nothing
             "-normal-" * string(pkg_info["git-tree-sha1"])
@@ -145,6 +148,8 @@ else
     frommanifest(manifest::Dict{UUID, PackageEntry}, uuid) = manifest[uuid]
 
     function get_filename_from_name(manifest, uuid)
+        haskey(manifest, uuid) || return nothing
+
         pkg_info = manifest[uuid]
 
         tree_hash = VERSION >= v"1.3" ? pkg_info.tree_hash : get(pkg_info.other, "git-tree-sha1", nothing)


### PR DESCRIPTION
This is a better (=less bugs) version of https://github.com/julia-vscode/SymbolServer.jl/pull/101.

And this time I won't merge things even when CI is broken :)

Fixes https://github.com/julia-vscode/SymbolServer.jl/issues/104.