### PR TITLE
Do not crash when env can't be read

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -27,7 +27,13 @@ include("utils.jl")
 
 store_path = length(ARGS)==1 ? ARGS[1] : abspath(joinpath(@__DIR__, "..", "store"))
 
-ctx = Pkg.Types.Context()
+ctx = try
+    Pkg.Types.Context()
+catch err
+    isa(err, Base.LoadError) || rethrow()
+    @info "Package environment can't be read."
+    exit()
+end
 
 server = Server(store_path, ctx, Dict{Any,Any}())
 


### PR DESCRIPTION
If the current env can't be read we now no longer crash but just exit. Fixes a bug from crash reporting.