### PR TITLE
Add symserv progress and harden against segfaults

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,8 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "1"

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -4,6 +4,7 @@ export SymbolServerInstance, getstore
 
 using Serialization, Pkg, SHA
 using Base: UUID, Process
+import Sockets, UUIDs
 
 include("symbols.jl")
 include("utils.jl")
@@ -19,7 +20,7 @@ mutable struct SymbolServerInstance
     end
 end
 
-function getstore(ssi::SymbolServerInstance, environment_path::AbstractString)
+function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, progress_callback=nothing, error_handler=nothing)
     !ispath(environment_path) && return :success, deepcopy(stdlibs)
 
     jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
@@ -44,7 +45,51 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString)
 
     use_code_coverage = Base.JLOptions().code_coverage
 
-    p = open(pipeline(Cmd(`$jl_cmd --code-coverage=$(use_code_coverage==0 ? "none" : "user") --startup-file=no --compiled-modules=no --history-file=no --project=$environment_path $server_script $(ssi.store_path)`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
+    currently_loading_a_package = false
+    current_package_name = ""
+
+    pipename = "\\\\.\\pipe\\vscodesymserv-$(UUIDs.uuid4())"
+
+    server_is_ready = Channel(1)
+
+    @async try
+        server = Sockets.listen(pipename)
+
+        put!(server_is_ready, nothing)
+
+        conn = Sockets.accept(server)
+
+        s = readline(conn)
+
+        while s!="" && isopen(conn)
+            parts = split(s, ';')
+            if parts[1]=="STARTLOAD"
+                currently_loading_a_package = true
+                current_package_name = parts[2]
+                current_package_uuid = parts[3]
+                current_package_version = parts[4]
+                progress_callback!==nothing && progress_callback(current_package_name)
+            elseif parts[1]=="STOPLOAD"
+                currently_loading_a_package = false
+            elseif parts[1]=="PROCESSPKG"
+                progress_callback!==nothing && progress_callback(parts[2])
+            else
+                error("Unknown command.")
+            end
+            s = readline(conn)
+        end
+    catch err
+        bt = catch_backtrace()
+        if error_handler!==nothing
+            error_handler(err, bt)
+        else
+            Base.display_error(stderr, err, bt)
+        end        
+    end
+
+    take!(server_is_ready)
+
+    p = open(pipeline(Cmd(`$jl_cmd --code-coverage=$(use_code_coverage==0 ? "none" : "user") --startup-file=no --compiled-modules=no --history-file=no --project=$environment_path $server_script $(ssi.store_path) $pipename`, env = env_to_use), stderr = stderr_for_client_process), read = true, write = true)
     ssi.process = p
 
     if success(p)
@@ -59,7 +104,11 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString)
         
         return :canceled, nothing
     else
-        return :failure, stderr_for_client_process
+        if currently_loading_a_package
+            return :package_load_crash, (package_name = current_package_name, stderr=stderr_for_client_process)
+        else
+            return :failure, stderr_for_client_process
+        end
     end
 end
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,11 @@
 module SymbolServer
 
+import Sockets
+
+pipename = length(ARGS) > 1 ? ARGS[2] : nothing
+
+conn = pipename!==nothing ? Sockets.connect(pipename) : nothing
+
 start_time = time_ns()
 
 # Try to lower the priority of this process so that it doesn't block the
@@ -25,7 +31,7 @@ using Base: UUID
 include("symbols.jl")
 include("utils.jl")
 
-store_path = length(ARGS)==1 ? ARGS[1] : abspath(joinpath(@__DIR__, "..", "store"))
+store_path = length(ARGS)>0 ? ARGS[1] : abspath(joinpath(@__DIR__, "..", "store"))
 
 ctx = Pkg.Types.Context()
 
@@ -63,7 +69,7 @@ for (pk_name, uuid) in toplevel_pkgs
 
             if sha_pkg(frommanifest(ctx.env.manifest, uuid)) != cached_version.sha
                 @info "Now recaching package $pk_name ($uuid)"
-                cache_package(server.context, uuid, server.depot)
+                cache_package(server.context, uuid, server.depot, conn)
             else
                 @info "Package $pk_name ($uuid) is cached."
             end
@@ -72,7 +78,7 @@ for (pk_name, uuid) in toplevel_pkgs
         end
     else
         @info "Now caching package $pk_name ($uuid)"
-        cache_package(server.context, uuid, server.depot)
+        cache_package(server.context, uuid, server.depot, conn)
         # Next write all package info to disc
         for  (uuid, pkg) in server.depot
             filename = get_filename_from_name(ctx.env.manifest, uuid)


### PR DESCRIPTION
This fixes another problem from crash reporting. Sometimes the symbol server crashes with a segfault because a package that we load has some really buggy code. Our `try catch` for these situations doesn't help. In general, we don't want to send a crash report for those cases: it is not our fault, so we shouldn't count this as a failure on our end.

This PR (and the companion PRs in LS and the client) works around this by adding a back communication channel from the symbol server to the LS process. The symbol server there notifies the LS "I will try to load package X now". If the symserver then crashes, the LS knows that it was a segfault in a package and sends a special trace event via telemetry. As soon as the symserver is done loading the user package it sends a message "I'm done loading package X" to the LS, so the LS now knows that if the symserver crashes after that notification, there is just a bug in the symserver that we should report via crash reporting.

As a small side bonus we get nicer progress reporting for the indexing process :)

Requires https://github.com/julia-vscode/LanguageServer.jl/pull/591 and https://github.com/julia-vscode/julia-vscode/pull/1043.

This is finicky to test, but I did try out a whole variety of different crash situations and it seems to work.