### PR TITLE
Fix pipename for symserver communication

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -48,7 +48,7 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, p
     currently_loading_a_package = false
     current_package_name = ""
 
-    pipename = "\\\\.\\pipe\\vscodesymserv-$(UUIDs.uuid4())"
+    pipename = Sys.iswindows() ? "\\\\.\\pipe\\vscjlsymserv-$(UUIDs.uuid4())" : joinpath(tempdir(), "vscjlsymserv-$(UUIDs.uuid4())")
 
     server_is_ready = Channel(1)
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/SymbolServer.jl/issues/116. Fixes https://github.com/julia-vscode/SymbolServer.jl/issues/118. Hopefully, but in any case, this is a pretty stupid bug.