### PR TITLE
Make sure we always have access to the stdlibs in the server

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -25,6 +25,9 @@ end
 module LoadingBay
 end
 
+# Make sure we can load stdlibs 
+!in("@stdlib",LOAD_PATH) && push!(LOAD_PATH, "@stdlib")
+
 using Serialization, Pkg, SHA
 using Base: UUID
 


### PR DESCRIPTION
This is a speculative fix for [this crash report](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22Name%22%3A%22julia-vscode%22%2C%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%7D/DataModel/%7B%22eventId%22%3A%2217d096d3-8616-11ea-84ac-67bc3467b635%22%2C%22timestamp%22%3A%222020-04-24T10%3A28%3A39.079Z%22%2C%22cacheId%22%3A%2215585051-ec3e-4f4b-a164-ea0936c017e0%22%2C%22eventTable%22%3A%22exceptions%22%7D).