### PR TITLE
Store list of modules used by another

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -174,6 +174,7 @@ end
 
 function cache_module(m::Module, mname::VarRef = VarRef(m), pkg_deps = Symbol[], isexported = true)
     allnames = names(m, all = true, imported = true)
+    isdefined(m, :parse) && !(:parse in allnames) && push!(allnames, :parse)
     exportednames = names(m)
     cache = ModuleStore(mname, Dict{Symbol,Any}(), _doc(m), isexported, exportednames)
     for name in allnames


### PR DESCRIPTION
Adds a field to `ModuleStore` that holds used modules and make sure that a VarRef to those modules is stored in the values list.

Not necessarily breaking but will invalidate cache stores and will require a minor ver bump to make use of the new field