### PR TITLE
refactor of how symbols are pulled from packages

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -187,6 +187,7 @@ function load_package_from_cache_into_store!(ssi::SymbolServerInstance, uuid, ma
         end
     else
         @warn "$(pe_name) not stored on disc"
+        store[Symbol(pe_name)] = ModuleStore(VarRef(nothing, Symbol(pe_name)), Dict{Symbol,Any}(), "$pe_name failed to load.", true, Symbol[], Symbol[])
     end
 end
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -151,6 +151,7 @@ end
 
 # Which project dependencies did't we load?
 for (pkg_name, uuid) in toplevel_pkgs
+    uuid = uuid isa String ? UUID(uuid) : uuid # julia versions < 1.? store UUIDs as Strings
     if !(uuid in keys(server.depot))
         pe = frommanifest(ctx, uuid)
         server.depot[uuid] = Package(pkg_name, ModuleStore(VarRef(nothing, Symbol(pkg_name)), Dict(), "Failed to load package.", false, Symbol[], Symbol[]), version(pe), uuid, sha_pkg(pe))

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,5 @@
 module SymbolServer
-
+errs = open("/tmp/SSerr.txt", "a")
 import Sockets
 
 pipename = length(ARGS) > 1 ? ARGS[2] : nothing
@@ -44,7 +44,31 @@ catch err
     exit()
 end
 
-server = Server(store_path, ctx, Dict{Any,Any}())
+server = Server(store_path, ctx, Dict{UUID,Package}())
+
+function load_package(c::Pkg.Types.Context, uuid, conn)
+    isinmanifest(c, uuid isa String ? Base.UUID(uuid) : uuid) || return
+    pe_name = packagename(c, uuid)
+    pid = Base.PkgId(uuid isa String ? Base.UUID(uuid) : uuid, pe_name)
+    write(errs, "Trying to load $pe_name ...")
+    if pid in keys(Base.loaded_modules)
+        conn!==nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion")
+        LoadingBay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
+        m = getfield(LoadingBay, Symbol(pe_name))
+        write(errs, "was already available\n")
+    else
+        m = try
+            conn!==nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion")
+            LoadingBay.eval(:(import $(Symbol(pe_name))))
+            conn!==nothing && println(conn, "STOPLOAD;$pe_name")
+            m = getfield(LoadingBay, Symbol(pe_name))
+            write(errs, "loaded to LoadingBay\n")
+        catch e
+            write(errs, "failed with $e \n")
+            return
+        end
+    end
+end
 
 function write_cache(name, pkg)
     open(joinpath(server.storedir, name), "w") do io
@@ -60,6 +84,7 @@ function write_depot(server, ctx, written_caches)
         cache_path in written_caches && continue
         push!(written_caches, cache_path)
         @info "Now writing to disc $uuid"
+        write(errs, "$uuid written to cache\n")
         write_cache(cache_path, pkg)
     end
 end
@@ -68,10 +93,9 @@ written_caches = String[]
 
 # First get a list of all package UUIds that we want to cache
 toplevel_pkgs = deps(project(ctx))
-
+packages_to_load = []
 # Next make sure the cache is up-to-date for all of these
 for (pk_name, uuid) in toplevel_pkgs
-
     file_name = get_filename_from_name(ctx.env.manifest, uuid)
 
     # We sometimes have UUIDs in the project file that are not in the 
@@ -87,11 +111,9 @@ for (pk_name, uuid) in toplevel_pkgs
             cached_version = open(cache_path) do io
                 deserialize(io)
             end
-
             if sha_pkg(frommanifest(ctx.env.manifest, uuid)) != cached_version.sha
-                @info "Outdated sha, recaching package $pk_name ($uuid)"
-                cache_package(server.context, uuid, server.depot, conn)
-                write_depot(server, ctx, written_caches)
+                @info "Outdated sha, will recache package $pk_name ($uuid)"
+                push!(packages_to_load, uuid)
             else
                 @info "Package $pk_name ($uuid) is cached."
             end
@@ -99,13 +121,36 @@ for (pk_name, uuid) in toplevel_pkgs
             @info "Package $pk_name ($uuid) is cached."
         end
     else
-        @info "Now caching package $pk_name ($uuid)"
-        cache_package(server.context, uuid, server.depot, conn)
-        # Next write all package info to disc
-        write_depot(server, ctx, written_caches)
+        @info "Will cache package $pk_name ($uuid)"
+        push!(packages_to_load, uuid)
     end
 end
 
+# Load all packages together
+for uuid in packages_to_load
+    load_package(ctx, uuid, conn)
+end
+
+# Create image of whole package env. This creates the module structure only.
+env_symbols = getenvtree()
+for k in keys(env_symbols)
+    write(errs, "ENVTREE: $k\n")
+end
+# Populate the above with symbols
+symbols(env_symbols)
+
+# Wrap the `ModuleStore`s as `Package`s.
+for (pkg_name, cache) in env_symbols
+    pkg_name = String(pkg_name)
+    !isinmanifest(ctx, pkg_name) && continue
+    uuid = packageuuid(ctx, String(pkg_name))
+    pe = frommanifest(ctx, uuid)
+    server.depot[uuid] = Package(String(pkg_name), cache, version(pe), uuid, sha_pkg(pe))
+    write(errs, "$pkg_name written to depot\n")
+end
+
+# Write to disc
+write_depot(server, server.context, written_caches)
 end_time = time_ns()
 
 elapsed_time_in_s = (end_time-start_time)/1e9

--- a/src/server.jl
+++ b/src/server.jl
@@ -149,6 +149,14 @@ for (pkg_name, cache) in env_symbols
     # write(errs, "$pkg_name written to depot\n")
 end
 
+# Which project dependencies did't we load?
+for (pkg_name, uuid) in toplevel_pkgs
+    if !(uuid in keys(server.depot))
+        pe = frommanifest(ctx, uuid)
+        server.depot[uuid] = Package(pkg_name, ModuleStore(VarRef(nothing, Symbol(pkg_name)), Dict(), "Failed to load package.", false, Symbol[], Symbol[]), version(pe), uuid, sha_pkg(pe))
+    end
+end
+
 # Write to disc
 write_depot(server, server.context, written_caches)
 end_time = time_ns()

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,5 @@
 module SymbolServer
-errs = open("/tmp/SSerr.txt", "a")
+# errs = open("/tmp/SSerr.txt", "a")
 import Sockets
 
 pipename = length(ARGS) > 1 ? ARGS[2] : nothing
@@ -50,21 +50,21 @@ function load_package(c::Pkg.Types.Context, uuid, conn)
     isinmanifest(c, uuid isa String ? Base.UUID(uuid) : uuid) || return
     pe_name = packagename(c, uuid)
     pid = Base.PkgId(uuid isa String ? Base.UUID(uuid) : uuid, pe_name)
-    write(errs, "Trying to load $pe_name ...")
+    # write(errs, "Trying to load $pe_name ...")
     if pid in keys(Base.loaded_modules)
         conn!==nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion")
         LoadingBay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
         m = getfield(LoadingBay, Symbol(pe_name))
-        write(errs, "was already available\n")
+        # write(errs, "was already available\n")
     else
         m = try
             conn!==nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion")
             LoadingBay.eval(:(import $(Symbol(pe_name))))
             conn!==nothing && println(conn, "STOPLOAD;$pe_name")
             m = getfield(LoadingBay, Symbol(pe_name))
-            write(errs, "loaded to LoadingBay\n")
+            # write(errs, "loaded to LoadingBay\n")
         catch e
-            write(errs, "failed with $e \n")
+            # write(errs, "failed with $e \n")
             return
         end
     end
@@ -84,7 +84,7 @@ function write_depot(server, ctx, written_caches)
         cache_path in written_caches && continue
         push!(written_caches, cache_path)
         @info "Now writing to disc $uuid"
-        write(errs, "$uuid written to cache\n")
+        # write(errs, "$uuid written to cache\n")
         write_cache(cache_path, pkg)
     end
 end
@@ -134,7 +134,7 @@ end
 # Create image of whole package env. This creates the module structure only.
 env_symbols = getenvtree()
 for k in keys(env_symbols)
-    write(errs, "ENVTREE: $k\n")
+    # write(errs, "ENVTREE: $k\n")
 end
 # Populate the above with symbols
 symbols(env_symbols)
@@ -146,7 +146,7 @@ for (pkg_name, cache) in env_symbols
     uuid = packageuuid(ctx, String(pkg_name))
     pe = frommanifest(ctx, uuid)
     server.depot[uuid] = Package(String(pkg_name), cache, version(pe), uuid, sha_pkg(pe))
-    write(errs, "$pkg_name written to depot\n")
+    # write(errs, "$pkg_name written to depot\n")
 end
 
 # Write to disc

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -257,7 +257,7 @@ function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
             elseif m === parentmodule(x)
                 cache[s] = getmoduletree(x, amn, visited)
             else
-                @warn "We shouldn't be able to get here, marking submodule $s in $m"
+                cache[s] = VarRef(x)
             end
         end
     end

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -16,6 +16,7 @@ struct ModuleStore <: SymStore
     used_modules::Vector{Symbol}
 end
 
+ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), "", true, names(m), Symbol[])
 Base.getindex(m::ModuleStore, k) = m.vals[k]
 Base.setindex!(m::ModuleStore, v, k) = (m.vals[k] = v)
 Base.haskey(m::ModuleStore, k) = haskey(m.vals, k)
@@ -107,7 +108,7 @@ function cache_methods(f, mod = nothing, exported = false)
         return ms
     end
     for m in methods0
-        if mod === nothing || mod === m[3].module || (exported && issubmodof(m[3].module, mod))
+        if mod === nothing || mod === m[3].module #|| (exported && issubmodof(m[3].module, mod))
             if true # Get return types? setting to false is costly
                 ty = Any
             elseif isdefined(m[3], :generator) && !Base.may_invoke_generator(m[3], types, m[2])
@@ -174,76 +175,137 @@ function apply_to_everything(f, m = nothing, visited = Base.IdSet{Module}())
 end
 
 
-function cache_module(m::Module, mname::VarRef = VarRef(m), pkg_deps = Symbol[], isexported = true)
-    allnames = names(m, all = true, imported = true)
-    exportednames = filter(n->isdefined(m, n),names(m))
-    cache = ModuleStore(mname, Dict{Symbol,Any}(), _doc(m), isexported, exportednames, Symbol[])
-    for name in allnames
-        !isdefined(m, name) && continue
-        x = getfield(m, name)
-        vname = VarRef(mname, name)
-        if x isa Module
-            name == :Main && continue
-            if x == m
-                cache[name] = VarRef(x)
-            elseif parentmodule(x) == m
-                cache[name] = cache_module(x, VarRef(mname, name), pkg_deps, name in exportednames)
-            else
-                cache[name] = VarRef(x)
+
+function oneverything(f, m = nothing, visited = Base.IdSet{Module}())
+    if m isa Module
+        push!(visited, m)
+        for s in names(m, all = true)
+            !isdefined(m, s) && continue
+            x = getfield(m, s)
+            f(m, s, x)
+            if x isa Module && !in(x, visited)
+                oneverything(f, x, visited)
             end
-        elseif x isa DataType
-            cache[name] = DataTypeStore(x, m, name in exportednames)
-        elseif x isa Function
-            cache[name] = FunctionStore(x, m, name in exportednames)
-        else
-            cache[name] = GenericStore(VarRef(VarRef(m), name), FakeTypeName(typeof(x)), _doc(x), name in exportednames)
+        end
+    else
+        for m in Base.loaded_modules_array()
+            in(m, visited) || oneverything(f, m, visited)
         end
     end
+end
 
-    apply_to_everything(
-        function (x)
-            x = Base.unwrap_unionall(x)
-            if x isa DataType && parentmodule(x) !== m && !Base.isvarargtype(x)
-                if supertype(x).name == Function.name && isdefined(x, :instance) && !haskey(cache, nameof(x.instance))
-                    f = x.instance
-                    ms = cache_methods(x.instance, m)
-                    if !isempty(ms)
-                        cache[nameof(x.instance)] = FunctionStore(VarRef(VarRef(m), nameof(x.instance)), ms, "", VarRef(VarRef(parentmodule(x)), nameof(x)), false)
-                    end
-                elseif !haskey(cache, nameof(x))
-                    ms = cache_methods(x, m)
-                    if !isempty(ms)
-                        cache[nameof(x)] = FunctionStore(VarRef(VarRef(m), nameof(x)), ms, "", VarRef(VarRef(parentmodule(x)), nameof(x)), false)
-                    end
+function allnames() 
+    symbols = Base.IdSet{Symbol}()
+    oneverything((m, s, x)->push!(symbols, s))
+    return symbols
+end
+
+function allmodulenames() 
+    symbols = Base.IdSet{Symbol}()
+    oneverything((m, s, x)->(x isa Module && push!(symbols, s)))
+    return symbols
+end
+
+function allthingswithmethods() 
+    symbols = Base.IdSet{Any}()
+    oneverything(function (m, s, x) 
+    if !Base.isvarargtype(x) && !isempty(methods(x))
+        push!(symbols, x)
+    end
+    end)
+    return symbols
+end
+
+function allmethods() 
+    ms = Method[]
+    oneverything(function (m, s, x) 
+    if !Base.isvarargtype(x) && !isempty(methods(x))
+        append!(ms, methods(x))
+    end
+    end)
+    return ms
+end
+
+usedby(outer, inner) = outer !== inner && isdefined(outer, nameof(inner)) && getproperty(outer, nameof(inner)) === inner && all(isdefined(outer, name) || !isdefined(inner, name) for name in names(inner))
+istoplevelmodule(m) = parentmodule(m) === m || parentmodule(m) === Main
+
+function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
+    push!(visited, m)
+    cache = ModuleStore(m)
+    for s in names(m, all = true)
+        !isdefined(m, s) && continue
+        x = getfield(m, s)
+        if x isa Module && !in(x, visited)
+            if istoplevelmodule(x)
+                cache[s] = VarRef(x)
+            else
+                cache[s] = getmoduletree(x, amn, visited)
+            end
+        end
+    end
+    for n in amn
+        if n !== nameof(m) && isdefined(m, n)
+            x = getfield(m, n)
+            if x isa Module 
+                if !istoplevelmodule(x) && !haskey(cache, n)
+                    cache[n] = VarRef(x)
                 end
-            elseif x isa Module
-                # `using`ed modules don't get listed 
-                if isdefined(m, nameof(x))
-                    if !(nameof(x) in cache.used_modules) && all(isdefined(m, name2) || !isdefined(x, name2) for name2 in names(x)) && x != m
-                        push!(cache.used_modules, nameof(x))
-                    end
-                    if !haskey(cache.vals, nameof(x))
-                        cache.vals[nameof(x)] = VarRef(x)
-                    end
+                if usedby(m, x)
+                    push!(cache.used_modules, n)
                 end
             end
-        end,
-    nothing)
-
-    for d in pkg_deps
-        if !haskey(cache, d) && isdefined(m, d) && getfield(m, d) isa Module
-            x = getfield(m, d)
-            cache[d] = VarRef(x)
         end
     end
     cache
 end
 
+function getenvtree(names = nothing)
+    amn = allmodulenames()
+    EnvStore(nameof(m) => getmoduletree(m, amn) for m in Base.loaded_modules_array() if names === nothing || nameof(m) in names)
+end
+
+function symbols(env, m = nothing, an = allnames(), visited = Base.IdSet{Module}())
+    if m isa Module
+        cache = _lookup(VarRef(m), env)
+        cache === nothing && return 
+        push!(visited, m)
+        for s in an
+            !isdefined(m, s) && continue
+            x = getfield(m, s)
+            if x isa DataType
+                cache[s] = DataTypeStore(x, m, s in names(m))
+            elseif x isa Function
+                if parentmodule(x) === m 
+                    cache[s] = FunctionStore(x, m, s in names(m))
+                elseif any(met.module == m for met in methods(x))
+                    cache[s] = FunctionStore(x, m, s in names(m))
+                else
+                    cache[s] = VarRef(VarRef(parentmodule(x)), nameof(x))
+                end
+            elseif x isa Module
+                if x === m
+                    cache[s] = VarRef(x)
+                elseif parentmodule(x) === m
+                    symbols(env, x, an, visited)
+                else
+                    cache[s] = VarRef(x)
+                end 
+            else
+                cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(x), s in names(m))
+            end
+        end
+    else
+        for m in Base.loaded_modules_array()
+            in(m, visited) || symbols(env, m, an, visited)
+        end
+    end
+end
+
+
 function load_core()
     c = Pkg.Types.Context()
-    cache = EnvStore()
-    cache[:Core] = cache_module(Core, VarRef(nothing, :Core))
-    cache[:Base] = cache_module(Base, VarRef(nothing, :Base))
+    cache = getenvtree([:Core,:Base])
+    symbols(cache)
 
     # Add special cases for built-ins
     let f = cache[:Base][:include]
@@ -305,40 +367,6 @@ function load_core()
     return cache
 end
 
-function cache_package(c::Pkg.Types.Context, uuid, depot::Dict, conn)
-    uuid in keys(depot) && return
-    isinmanifest(c, uuid isa String ? Base.UUID(uuid) : uuid) || return
-    
-    pe = frommanifest(c, uuid)
-    pe_name = packagename(c, uuid)
-    pid = Base.PkgId(uuid isa String ? Base.UUID(uuid) : uuid, pe_name)
-
-    if pid in keys(Base.loaded_modules)
-        conn!==nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion")
-        LoadingBay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
-        m = getfield(LoadingBay, Symbol(pe_name))
-    else
-        m = try
-            conn!==nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion")
-            LoadingBay.eval(:(import $(Symbol(pe_name))))
-            conn!==nothing && println(conn, "STOPLOAD;$pe_name")
-            m = getfield(LoadingBay, Symbol(pe_name))
-        catch e
-            depot[uuid] = Package(pe_name, ModuleStore(VarRef(nothing, Symbol(pe_name)), Dict(), "Failed to load package.", false, Symbol[], Symbol[]), version(pe), uuid, sha_pkg(pe))
-            return
-        end
-    end
-    depot[uuid] = Package(pe_name, cache_module(m, VarRef(m), Symbol.(collect(keys(deps(pe))))), version(pe), uuid, sha_pkg(pe))
-
-    pe_path = pathof(m) isa String && !isempty(pathof(m)) ? joinpath(dirname(pathof(m)), "..") : nothing
-
-    # Dependencies
-    for pkg in deps(pe)
-        cache_package(c, packageuuid(pkg), depot, conn)
-    end
-
-    return
-end
 
 function collect_extended_methods(depot::Dict, extendeds = Dict{VarRef,Vector{VarRef}}())
     for m in depot

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -388,7 +388,7 @@ function load_core()
 end
 
 
-function collect_extended_methods(depot::Dict, extendeds = Dict{VarRef,Vector{VarRef}}())
+function collect_extended_methods(depot::EnvStore, extendeds = Dict{VarRef,Vector{VarRef}}())
     for m in depot
         collect_extended_methods(m[2], extendeds, m[2].name)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -258,12 +258,12 @@ function _lookup(vr::VarRef, depot::EnvStore, cont = false)
 end
 
 """
-    maybe_getfield(k::Symbol , m::SymbolServer.ModuleStore, server)
+    maybe_getfield(k::Symbol , m::ModuleStore, server)
 
 Try to get `k` from `m`. This includes: unexported variables, and variables
 exported by modules used within `m`.
 """
-function maybe_getfield(k::Symbol , m::SymbolServer.ModuleStore, envstore)
+function maybe_getfield(k::Symbol , m::ModuleStore, envstore)
     if haskey(m.vals, k)
         return m.vals[k]
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -243,7 +243,7 @@ function _lookup(vr::VarRef, depot::EnvStore, cont = false)
             return nothing
         end
     else
-        par = _lookup(vr.parent, depot)
+        par = _lookup(vr.parent, depot, cont)
         if par !== nothing && par isa ModuleStore && haskey(par, vr.name)
             val = par[vr.name]
             if cont && val isa VarRef

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -192,6 +192,7 @@ function sha_pkg(pe::PackageEntry)
 end
 
 function _doc(object)
+    try
     binding = Base.Docs.aliasof(object, typeof(object))
     !(binding isa Base.Docs.Binding) && return ""
     sig = Union{}
@@ -225,6 +226,9 @@ function _doc(object)
         nothing
     end
     return md === nothing ? "" : string(md)
+    catch e
+        return ""
+    end
 end
 
 _lookup(vr::FakeUnion, depot::EnvStore, cont = false) = nothing


### PR DESCRIPTION
Changes how symbols are cached - now caches the entire environment as existing in the symbol server process all in one go rather than trying to treat modules as separate objects (they're not). 

This appears to be significantly faster than the previous approach.

Adds a test to ensure all the symbols we need are cached.

Todo: Add test to check that  function methods are assigned to the correct FunctionStores within each module.