### PR TITLE
Improve performance with `recursive_copy`

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -85,7 +85,7 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, p
             error_handler(err, bt)
         else
             Base.display_error(stderr, err, bt)
-        end        
+        end
     end
 
     take!(server_is_ready)

--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -22,7 +22,7 @@ mutable struct SymbolServerInstance
 end
 
 function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, progress_callback=nothing, error_handler=nothing)
-    !ispath(environment_path) && return :success, deepcopy(stdlibs)
+    !ispath(environment_path) && return :success, recursive_copy(stdlibs)
 
     jl_cmd = joinpath(Sys.BINDIR, Base.julia_exename())
     server_script = joinpath(@__DIR__, "server.jl")
@@ -96,13 +96,13 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, p
     if success(p)
         # Now we create a new symbol store and load everything into that
         # from disc
-        new_store = deepcopy(stdlibs)
+        new_store = recursive_copy(stdlibs)
         load_project_packages_into_store!(ssi, environment_path, new_store)
 
         return :success, new_store
     elseif p in ssi.canceled_processes
         delete!(ssi.canceled_processes, p)
-        
+
         return :canceled, nothing
     else
         if currently_loading_a_package

--- a/src/faketypes.jl
+++ b/src/faketypes.jl
@@ -40,19 +40,19 @@ struct FakeTypeofBottom end
 struct FakeUnion
     a
     b
-    FakeUnion(u::Union) = new(FakeTypeName(u.a, justname = true), FakeTypeName(u.b, justname = true))
 end
+FakeUnion(u::Union) = FakeUnion(FakeTypeName(u.a, justname = true), FakeTypeName(u.b, justname = true))
 struct FakeTypeVar
     name::Symbol
     lb
     ub
-    FakeTypeVar(tv::TypeVar) = new(tv.name, FakeTypeName(tv.lb, justname = true), FakeTypeName(tv.ub, justname = true))
 end
+FakeTypeVar(tv::TypeVar) = FakeTypeVar(tv.name, FakeTypeName(tv.lb, justname = true), FakeTypeName(tv.ub, justname = true))
 struct FakeUnionAll
     var::FakeTypeVar
     body::Any
-    FakeUnionAll(ua::UnionAll) = new(FakeTypeVar(ua.var), FakeTypeName(ua.body, justname = true))
 end
+FakeUnionAll(ua::UnionAll) = FakeUnionAll(FakeTypeVar(ua.var), FakeTypeName(ua.body, justname = true))
 
 function _parameter(p::T) where T
     if p isa Union{Int,Symbol,Bool,Char}

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -30,7 +30,7 @@ struct Package
     uuid::Base.UUID
     sha
 end
-Package(name::String, val::ModuleStore, ver, uuid::String, sha) = Package(name, val, ver, Base.UUID(uuid), sha) 
+Package(name::String, val::ModuleStore, ver, uuid::String, sha) = Package(name, val, ver, Base.UUID(uuid), sha)
 
 struct MethodStore
     name::Symbol
@@ -85,7 +85,7 @@ end
 
 function clean_method_path(m::Method)
     path = String(m.file)
-    if !isabspath(path) 
+    if !isabspath(path)
         path = Base.find_source_file(path)
         if path === nothing
             path = ""
@@ -138,7 +138,7 @@ function cache_methods(f, mod = nothing, exported = false)
                 push!(MS.kws, kw)
             end
             push!(ms, MS)
-            i +=1 
+            i +=1
         end
     end
     # Go back and add kws to methods defined in the same place as others with kws.
@@ -158,7 +158,7 @@ getargnames(m::Method) = Base.method_argnames(m)
 @static if length(first(methods(Base.kwarg_decl)).sig.parameters) == 2
     getkws = Base.kwarg_decl
 else
-    function getkws(m::Method) 
+    function getkws(m::Method)
         sig = Base.unwrap_unionall(m.sig)
         length(sig.parameters) == 0 && return []
         sig.parameters[1] isa Union && return []
@@ -166,7 +166,7 @@ else
         fname = Base.unwrap_unionall(sig.parameters[1]).name
         if isdefined(fname.mt, :kwsorter)
             Base.kwarg_decl(m, typeof(fname.mt.kwsorter))
-        else 
+        else
             []
         end
     end
@@ -210,21 +210,21 @@ function oneverything(f, m = nothing, visited = Base.IdSet{Module}())
     end
 end
 
-function allnames() 
+function allnames()
     symbols = Base.IdSet{Symbol}()
     oneverything((m, s, x)->push!(symbols, s))
     return symbols
 end
 
-function allmodulenames() 
+function allmodulenames()
     symbols = Base.IdSet{Symbol}()
     oneverything((m, s, x)->(x isa Module && push!(symbols, s)))
     return symbols
 end
 
-function allthingswithmethods() 
+function allthingswithmethods()
     symbols = Base.IdSet{Any}()
-    oneverything(function (m, s, x) 
+    oneverything(function (m, s, x)
     if !Base.isvarargtype(x) && !isempty(methods(x))
         push!(symbols, x)
     end
@@ -232,9 +232,9 @@ function allthingswithmethods()
     return symbols
 end
 
-function allmethods() 
+function allmethods()
     ms = Method[]
-    oneverything(function (m, s, x) 
+    oneverything(function (m, s, x)
     if !Base.isvarargtype(x) && !isempty(methods(x))
         append!(ms, methods(x))
     end
@@ -264,7 +264,7 @@ function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
     for n in amn
         if n !== nameof(m) && isdefined(m, n)
             x = getfield(m, n)
-            if x isa Module 
+            if x isa Module
                 if !istoplevelmodule(x) && !haskey(cache, n)
                     cache[n] = VarRef(x)
                 end
@@ -285,19 +285,19 @@ end
 function symbols(env, m = nothing, an = allnames(), visited = Base.IdSet{Module}())
     if m isa Module
         cache = _lookup(VarRef(m), env, true)
-        cache === nothing && return 
+        cache === nothing && return
         push!(visited, m)
         for s in an
             !isdefined(m, s) && continue
             x = getfield(m, s)
             if x isa DataType
-                if parentmodule(x) === m 
+                if parentmodule(x) === m
                     cache[s] = DataTypeStore(x, m, s in names(m))
                 else
                     cache[s] = FunctionStore(x, m, s in names(m))
                 end
             elseif x isa Function
-                if parentmodule(x) === m 
+                if parentmodule(x) === m
                     cache[s] = FunctionStore(x, m, s in names(m))
                 elseif any(met.module == m for met in methods(x))
                     cache[s] = FunctionStore(x, m, s in names(m))
@@ -311,7 +311,7 @@ function symbols(env, m = nothing, an = allnames(), visited = Base.IdSet{Module}
                     symbols(env, x, an, visited)
                 else
                     cache[s] = VarRef(x)
-                end 
+                end
             else
                 cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(x), s in names(m))
             end
@@ -380,8 +380,8 @@ function load_core()
         MethodStore[
             MethodStore(:ccall, :Core, "built-in", 0, [:args => FakeTypeName(Vararg{Any,N} where N)], Symbol[], FakeTypeName(Any)) # General method - should be fixed
         ],
-        "`ccall((function_name, library), returntype, (argtype1, ...), argvalue1, ...)`\n`ccall(function_name, returntype, (argtype1, ...), argvalue1, ...)`\n`ccall(function_pointer, returntype, (argtype1, ...), argvalue1, ...)`\n\nCall a function in a C-exported shared library, specified by the tuple (`function_name`, `library`), where each component is either a string or symbol. Instead of specifying a library, one\ncan also use a `function_name` symbol or string, which is resolved in the current process. Alternatively, `ccall` may also be used to call a function pointer `function_pointer`, such as one\nreturned by `dlsym`.\n\nNote that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression.\n\nEach `argvalue` to the `ccall` will be converted to the corresponding `argtype`, by automatic insertion of calls to `unsafe_convert(argtype, cconvert(argtype, argvalue))`. (See also the documentation for `unsafe_convert` and `cconvert` for further details.) In most cases, this simply results in a call to `convert(argtype, argvalue)`.", 
-        VarRef(VarRef(Core), :ccall), 
+        "`ccall((function_name, library), returntype, (argtype1, ...), argvalue1, ...)`\n`ccall(function_name, returntype, (argtype1, ...), argvalue1, ...)`\n`ccall(function_pointer, returntype, (argtype1, ...), argvalue1, ...)`\n\nCall a function in a C-exported shared library, specified by the tuple (`function_name`, `library`), where each component is either a string or symbol. Instead of specifying a library, one\ncan also use a `function_name` symbol or string, which is resolved in the current process. Alternatively, `ccall` may also be used to call a function pointer `function_pointer`, such as one\nreturned by `dlsym`.\n\nNote that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression.\n\nEach `argvalue` to the `ccall` will be converted to the corresponding `argtype`, by automatic insertion of calls to `unsafe_convert(argtype, cconvert(argtype, argvalue))`. (See also the documentation for `unsafe_convert` and `cconvert` for further details.) In most cases, this simply results in a call to `convert(argtype, argvalue)`.",
+        VarRef(VarRef(Core), :ccall),
         true)
     cache[:Core][Symbol("@__doc__")] = FunctionStore(VarRef(VarRef(Core), Symbol("@__doc__")), cache_methods(getfield(Core, Symbol("@__doc__"))), "", VarRef(VarRef(Core), Symbol("@__doc__")), true)
     # Accounts for the dd situation where Base.rand only has methods from Random which doesn't appear to be explicitly used.


### PR DESCRIPTION
I decided to see if I could determine whether there was any way to speed up LanguageServer. I'm not sure how to run it in "real" circumstances, but as a proxy I decided to profile the various files in its tests. It turns out there was exactly one obvious bottleneck: calls to `deepcopy(SymbolServer.stdlibs)`.

As a comment in this PR explains, `deepcopy` is safe and convenient but slow; its slowness comes from two factors:
- iterating over e.g., `fieldnames(typeof(x))` rather than creating a hand-crafted version for each struct type
- its mechanisms to avoid cycles when objects mutually reference each other

If you don't need to worry about cycles, you can do a *lot* better by defining your own recursive copy function, and that is done in this PR. There is a downside, mainly that as you modify types it's important to remember to update your implementation of `recursive_copy`, and new types require methods of their own. But the advantage is improved performance. For instance, with this PR and if you make the single change

```diff
diff --git a/src/languageserverinstance.jl b/src/languageserverinstance.jl
index 7cdbe4e..1852246 100644
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -70,7 +70,7 @@ mutable struct LanguageServerInstance
             depot_path,
             SymbolServer.SymbolServerInstance(depot_path, symserver_store_path),
             Channel(Inf),
-            deepcopy(SymbolServer.stdlibs),
+            SymbolServer.recursive_copy(SymbolServer.stdlibs),
             SymbolServer.collect_extended_methods(SymbolServer.stdlibs),
             false,
             DocumentFormat.FormatOptions(),
@@ -321,5 +321,3 @@ function Base.run(server::LanguageServerInstance)
         end
     end
 end
```
in LanguageServer.jl, then I get these benchmarks on LanguageServer's tests (run after `test_communication` since the other tests seem to use its results):

| Test script | Time, master | Time, this PR | Gain |
|:----------- | ------------:| -------------:| ----:|
| test_intellisense.jl | 0.40s | 0.04s | 10x |
| test_edit | 0.6s | 0.2s | 3x |
| test_actions | 0.4s | 0.035s | 11x |
| test_paths | 0.02s | 0.02s | no change |

As you can see, these are nothing to sneeze at. I am not sure whether these will translate into similar gains in real-world circumstances; is there a simple way to trigger indexing on a specific package from the REPL? I'd be happy to take a poke at that and see if there are more performance gains to be had.
