### PR TITLE
Improve performance with less specialization

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,24 +12,28 @@ CurrentModule = SymbolServer
 SymbolServer is a helper package for LanguageServer.jl that provides information about internal and exported variables of packages (without loading them). A package's symbol information is initially loaded in an external process but then stored on disc for (quick loading) future use.
 
 ## Installation and Usage
+
+[IDEs](https://en.wikipedia.org/wiki/Integrated_development_environment) that exploit SymbolServer should install it automatically; if you are an IDE user, you probably don't need to manually install or update SymbolServer.
+
+Developers and curious users can install it manually with
 ```julia
 using Pkg
 Pkg.add("SymbolServer")
 ```
+
+Loading it is similar to any other Julia package,
+
 ```julia
 using SymbolServer
 ```
-**Documentation**: [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://www.julia-vscode.org/SymbolServer.jl/dev)
 
-Documentation for working with Julia environments is available [here](https://github.com/JuliaLang/Pkg.jl).
+## Server API
 
-## API
 ```julia
 SymbolServerInstance(path_to_depot, path_to_store)
 ```
 
 Creates a new symbol server instance that works on a given Julia depot. This symbol server instance can be long lived, i.e. one can re-use it for different environments etc. If `path_to_store` is specified, cache files will be stored there, otherwise a standard location will be used.
-
 
 ```julia
 getstore(ssi::SymbolServerInstance, environment_path::AbstractString)
@@ -38,3 +42,22 @@ getstore(ssi::SymbolServerInstance, environment_path::AbstractString)
 Loads the symbols for the environment in `environment_path`. Returns a tuple, where the first element is a return status and the second element a payload. The status can be `:success` (in which case the second element is the new store), `:canceled` if another call to `getstore` was initiated before a previous one finished (with `nothing` as the payload), or `:failure` with the payload being the content of the error stream of the client process.
 
 This function is long running and should typically be called in an `@async` block.
+
+## Indexing API
+
+When a new environment is encountered, this environment must be indexed.
+Indexing can be run manually with the following:
+
+```julia
+using SymbolServer
+using Packages,You,Want,To,Index
+env = SymbolServer.getenvtree() # Create a tree of all modules within the current session, including submodules
+@time SymbolServer.symbols(env) # index everything
+```
+
+The last line performs indexing on the complete set of modules loaded into your session.
+To perform indexing on a single module,
+
+```julia
+@time SymbolServer.symbols(env, SomeModule) # index a single module
+```

--- a/src/faketypes.jl
+++ b/src/faketypes.jl
@@ -14,7 +14,7 @@ struct FakeTypeName
     parameters::Vector{Any}
 end
 
-function FakeTypeName(x; justname = false)
+function FakeTypeName(@nospecialize(x); justname = false)
     if x isa DataType
         xname = x.name
         xnamename = xname.name
@@ -54,10 +54,10 @@ struct FakeUnionAll
 end
 FakeUnionAll(ua::UnionAll) = FakeUnionAll(FakeTypeVar(ua.var), FakeTypeName(ua.body, justname = true))
 
-function _parameter(p::T) where T
+function _parameter(@nospecialize(p))
     if p isa Union{Int,Symbol,Bool,Char}
         p
-    elseif !(p isa Type) && isbitstype(T)
+    elseif !(p isa Type) && isbitstype(typeof(p))
         0
     elseif p isa Tuple
         _parameter.(p)

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -53,7 +53,7 @@ struct DataTypeStore <: SymStore
     exported::Bool
 end
 
-function DataTypeStore(t::DataType, parent_mod, exported)
+function DataTypeStore(@nospecialize(t::DataType), parent_mod, exported)
     parameters = map(t.parameters) do p
         _parameter(p)
     end
@@ -71,7 +71,7 @@ struct FunctionStore <: SymStore
     exported::Bool
 end
 
-function FunctionStore(f, parent_mod, exported)
+function FunctionStore(@nospecialize(f), parent_mod, exported)
     FunctionStore(VarRef(VarRef(parent_mod), nameof(f)), cache_methods(f, parent_mod, exported), _doc(f), VarRef(VarRef(parentmodule(f)), nameof(f)), exported)
 end
 
@@ -94,7 +94,7 @@ function clean_method_path(m::Method)
     return normpath(path)
 end
 
-function cache_methods(f, mod = nothing, exported = false)
+function cache_methods(@nospecialize(f), mod = nothing, exported = false)
     if isa(f, Core.Builtin)
         return MethodStore[]
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -191,7 +191,7 @@ function sha_pkg(pe::PackageEntry)
     path(pe) isa String && isdir(path(pe)) && isdir(joinpath(path(pe), "src")) ? sha2_256_dir(joinpath(path(pe), "src")) : nothing
 end
 
-function _doc(object)
+function _doc(@nospecialize(object))
     try
         binding = Base.Docs.aliasof(object, typeof(object))
         !(binding isa Base.Docs.Binding) && return ""
@@ -203,7 +203,7 @@ function _doc(object)
         results, groups = Base.Docs.DocStr[], Base.Docs.MultiDoc[]
     # Lookup `binding` and `sig` for matches in all modules of the docsystem.
         for mod in Base.Docs.modules
-            dict = Base.Docs.meta(mod)
+            dict = Base.Docs.meta(mod)::IdDict{Any,Any}
             if haskey(dict, binding)
                 multidoc = dict[binding]
                 push!(groups, multidoc)


### PR DESCRIPTION
~~This is "WIP" because it currently fails [two tests](https://github.com/julia-vscode/SymbolServer.jl/blob/054629cdd0aa8b937b7dda57cbc3692bf88562cd/test/runtests.jl#L42-L45) (just for a handful of `Core.Builltin`and/or `Core.Intrinsic` functions, I think). I'd appreciate some help figuring out how to fix them.~~

~~This takes two main strategies, control over specialization and greater caching, to improve package performance.~~

Several functions have to operate on arguments that have a huge number of different types: any function that takes a function or a type as an argument might, in principle, be specialized, but then used only once or a small handful of times. This marks such arguments with atsign-nospecialize annotations, to prevent them from being recompiled many times over.  Since this package has to use `isa` logic anyway, there is very little advantage in specialization and a big win in terms of compile time for avoiding it.

EDIT: the text below and much of the discussion below is no longer relevant to this PR (those issues will be resolved in a separate PR)

The other major strategy relies on caching. Here there are negatives, because we have to invalidate the cache if the LanguageServer has to process newly-added packages; I'm not sure if that ever happens, and if so where that invalidation should be done.

Of course, the advantage is performance. To major bottlenecks were:
- `Base._methods`: the issue is that two modules might define methods for the same `f` (e.g., `Base.convert` might be extended by multiple packages). However, `Base._methods` looks up methods across the whole session; we might as well save the result.
- `isdefined(m, n)` where `n` came from `allnames`. This was wasteful since it was iterating over all names defined throughout the entire session rather than just the names defined in a specific module.

With all that said, let's get to the numbers. Here was my test:
```julia
using SymbolServer
using Images, Profile, ProfileView  # Revise was also loaded
env = SymbolServer.getenvtree()
@time SymbolServer.symbols(env)

# And then run it a second time in the same session, just for fun (not sure this is relevant)
env = SymbolServer.getenvtree()
@time SymbolServer.symbols(env)
```

And here's the timing results:

| Run # | Time, master | Time, this PR | Gain |
|:----------- | ------------:| -------------:| ----:|
| 1 | 89.9s | 11.3s | 8x |
| 2 | 65.1s |  2.2s | 30x |

As you can see, the gains are pretty decent. I did the timing on top of #159, but I don't think that really changes this test very much.