### PR TITLE
show method locations

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -316,6 +316,7 @@ function Base.print(io::IO, m::MethodStore)
         i != length(m.sig) && print(io, ", ")
     end
     print(io, ")")
+    print(io, " in ", m.mod, " at ", normpath(m.file), ':', m.line)
 end
 
 function Base.print(io::IO, t::DataTypeStore)


### PR DESCRIPTION
make it more consistent with Base's print:
```julia
Base.bitshow is a Function.

  # 2 methods for generic function "bitshow":
  [1] bitshow(io::IO, B::BitArray) in Base at show.jl:2256
  [2] bitshow(B::BitArray) in Base at show.jl:2265
```