### PR TITLE
Add a couple of small performance tweaks

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -202,4 +202,14 @@ end
 
 const stdlibs = load_core()
 
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    Base.precompile(Tuple{Type{SymbolServer.DataTypeStore},SymbolServer.FakeTypeName,SymbolServer.FakeTypeName,Array{Any,1},Array{Any,1},Array{Symbol,1},Array{Any,1},String,Bool})
+    Base.precompile(Tuple{typeof(SymbolServer.cache_methods),Any,Dict{Symbol,SymbolServer.ModuleStore}})
+    Base.precompile(Tuple{typeof(SymbolServer.getenvtree)})
+    Base.precompile(Tuple{typeof(SymbolServer.symbols),Dict{Symbol,SymbolServer.ModuleStore}})
+    Base.precompile(Tuple{typeof(copy),Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple},Nothing,typeof(SymbolServer._parameter),Tuple{NTuple{4,Symbol}}}})
+end
+VERSION >= v"1.4.2" && _precompile_()
+
 end # module

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -515,7 +515,8 @@ function split_module_names(m::Module, allns)
             pop!(availablenames, n)
         end
     end
-    for u in get_used_modules(m)
+    allms = get_all_modules()
+    for u in get_used_modules(m, allms)
         for n in unsorted_names(u)
             if n in availablenames
                 push!(usinged_names, pop!(availablenames, n))

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -16,7 +16,7 @@ struct ModuleStore <: SymStore
     used_modules::Vector{Symbol}
 end
 
-ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), "", true, names(m), Symbol[])
+ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), "", true, unsorted_names(m), Symbol[])
 Base.getindex(m::ModuleStore, k) = m.vals[k]
 Base.setindex!(m::ModuleStore, v, k) = (m.vals[k] = v)
 Base.haskey(m::ModuleStore, k) = haskey(m.vals, k)
@@ -196,7 +196,7 @@ end
 function apply_to_everything(f, m = nothing, visited = Base.IdSet{Module}())
     if m isa Module
         push!(visited, m)
-        for s in names(m, all = true, imported = true)
+        for s in unsorted_names(m, all = true, imported = true)
             (!isdefined(m, s) || s == nameof(m)) && continue
             x = getfield(m, s)
             f(x)
@@ -217,7 +217,7 @@ function oneverything(f, m = nothing, visited = Base.IdSet{Module}())
     if m isa Module
         push!(visited, m)
         state = nothing
-        for s in names(m, all = true)
+        for s in unsorted_names(m, all = true)
             !isdefined(m, s) && continue
             x = getfield(m, s)
             state = f(m, s, x, state)
@@ -280,13 +280,13 @@ function allmethods()
     return ms
 end
 
-usedby(outer, inner) = outer !== inner && isdefined(outer, nameof(inner)) && getproperty(outer, nameof(inner)) === inner && all(isdefined(outer, name) || !isdefined(inner, name) for name in names(inner))
+usedby(outer, inner) = outer !== inner && isdefined(outer, nameof(inner)) && getproperty(outer, nameof(inner)) === inner && all(isdefined(outer, name) || !isdefined(inner, name) for name in unsorted_names(inner))
 istoplevelmodule(m) = parentmodule(m) === m || parentmodule(m) === Main
 
 function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
     push!(visited, m)
     cache = ModuleStore(m)
-    for s in names(m, all = true, imported = true)
+    for s in unsorted_names(m, all = true, imported = true)
         !isdefined(m, s) && continue
         x = getfield(m, s)
         if x isa Module
@@ -410,8 +410,8 @@ function load_core()
     cache[:Base][Symbol("@.")] = cache[:Base][Symbol("@__dot__")]
     cache[:Core][:Main] = GenericStore(VarRef(nothing, :Main), FakeTypeName(Module), _doc(Main), true)
     # Add built-ins
-    builtins = Symbol[nameof(getfield(Core, n).instance) for n in names(Core, all = true) if isdefined(Core, n) && getfield(Core, n) isa DataType && isdefined(getfield(Core, n), :instance) && getfield(Core, n).instance isa Core.Builtin]
-    cnames = names(Core)
+    builtins = Symbol[nameof(getfield(Core, n).instance) for n in unsorted_names(Core, all = true) if isdefined(Core, n) && getfield(Core, n) isa DataType && isdefined(getfield(Core, n), :instance) && getfield(Core, n).instance isa Core.Builtin]
+    cnames = unsorted_names(Core)
     for f in builtins
         if !haskey(cache[:Core], f)
             cache[:Core][f] = FunctionStore(getfield(Core, Symbol(f)), Core, Symbol(f) in cnames)
@@ -516,7 +516,7 @@ function split_module_names(m::Module, allns)
         end
     end
     for u in get_used_modules(m)
-        for n in names(u)
+        for n in unsorted_names(u)
             if n in availablenames
                 push!(usinged_names, pop!(availablenames, n))
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -340,6 +340,10 @@ extends_methods(f) = false
 extends_methods(f::FunctionStore) = f.name != f.extends
 get_top_module(vr::VarRef) = vr.parent === nothing ? vr.name : get_top_module(vr.parent)
 
+# Sorting is the main performance of calling `names`
+unsorted_names(m::Module; all::Bool = false, imported::Bool = false) =
+    ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint), m, all, imported)
+
 ## recursive_copy
 #
 # `deepcopy` is reliable but incredibly slow. Its slowness comes from two factors:


### PR DESCRIPTION
This adds a few optimizations that drop the time spent on the same workload described in the OP of #160 from 25.2s to 21.0s.

However, I think the "unsorted_names" is kind of a red herring, and I won't be remotely offended if you decide to just close this and go a different way. From a broader perspective, my sense is that `split_module_names` is doing something quite inefficient. It accounts for more than one-third of the total run time, and for comparison:

```julia
julia> using Images, Profile, ProfileView  # same workload as in #160
Gtk-Message: 06:47:57.888: Failed to load module "canberra-gtk-module"
Gtk-Message: 06:47:57.889: Failed to load module "canberra-gtk-module"

julia> using MethodAnalysis

julia> const allnames = Symbol[]
Symbol[]

julia> @time visit() do item
           if item isa Module
               append!(allnames, names(item, all=true, imported=true))
               return true
           end
           false
       end
  0.196790 seconds (607.61 k allocations: 38.474 MiB, 4.46% gc time)
```

I know `split_module_names` is doing a little more work than this, but if you profile the work seems essentially negligible: it's mostly from calling `unsorted_names` (which is why the sorting in `names` showed up on my profiling). I'm guessing it's doing it redundantly somehow. If you call it less, then I think the sorting is unlikely to be something that matters, which is why I say that I doubt you need much or any of the work in this PR.