### PR TITLE
export `include` from Base cache

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -412,6 +412,10 @@ function load_core()
     symbols(cache)
     cache[:Main] = ModuleStore(VarRef(nothing, :Main), Dict(), "", true, [], [])
 
+    # This is wrong. As per the docs the Base.include each module should have it's own
+    # version.
+    push!(cache[:Base].exportednames, :include) 
+
     # Add special cases for built-ins
     let f = cache[:Base][:include]
         cache[:Base][:include] = FunctionStore(f.name, cache[:Base][:MainInclude][:include].methods, f.doc, f.extends, true)


### PR DESCRIPTION
Reverts to previous handling of `include` before the slight refactor. This approach is obviously wrong - `Base.include` is not exported - and will be changed in the future.