### PR TITLE
fix paths of symbols in stdlibs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,20 +3,21 @@ uuid = "cf896787-08d5-524d-9de7-132aaa0cb996"
 version = "5.1.1-DEV"
 
 [deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]


### PR DESCRIPTION
Currently the locations of symbols in standard library are invalid for julia that is not built from source. E.g. `LinearAlgebra.eigen`'s location would be `/Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/InteractiveUtils/src/InteractiveUtils.jl:53` on macOS.
This is because of https://github.com/JuliaLang/julia/issues/26314 and I'm trying to fix this borrowing [the code in CodeTracking.jl to fix this issue](https://github.com/timholy/CodeTracking.jl/blob/afc73a957f5034cc7f02e084a91283c47882f92b/src/utils.jl#L87-L122).

@ZacLN is my understanding correct that SymbolServer only collects locations of methods, right ? Otherwise we need to use this kind of patching for other places as well.