### PR TITLE
improved name resolution

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -382,7 +382,6 @@ function symbols(env::EnvStore, m::Union{Module,Nothing} = nothing, allnames::Ba
         cache === nothing && return
         push!(visited, m)
         ns = all_names(m)
-        # internalnames, othernames = split_module_names(m, allnames)
         for s in ns
             !isdefined(m, s) && continue
             x = getfield(m, s)
@@ -429,23 +428,6 @@ function symbols(env::EnvStore, m::Union{Module,Nothing} = nothing, allnames::Ba
                 cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(x), s in getnames(m))
             end
         end
-        # for s in othernames
-        #     x = getfield(m, s)
-        #     if x isa Function
-        #         if x isa Core.IntrinsicFunction
-        #             cache[s] = VarRef(VarRef(Core.Intrinsics), nameof(x))
-        #         else
-        #             cache[s] = VarRef(VarRef(parentmodule(x)), nameof(x))
-        #         end
-        #     elseif x isa DataType
-        #         cache[s] = VarRef(VarRef(parentmodule(x)), nameof(x))
-        #     elseif x isa Module
-        #         cache[s] = VarRef(x)
-        #     else
-        #         # We'd like to have these as VarRef's but we don't know where they live.
-        #         cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(x), s in getnames(m))
-        #     end
-        # end
     else
         for m in Base.loaded_modules_array()
             in(m, visited) || symbols(env, m, allnames, visited)


### PR DESCRIPTION
The newly added `all_names` has a few advantages over `split_module_names`:
1. Seems to be about an order (or two) of magnitude faster:
```
julia> @time all_names(JSON);
  0.000248 seconds (51 allocations: 7.281 KiB)

julia> @time SymbolServer.split_module_names(JSON, allns);
  0.015986 seconds (19.93 k allocations: 1.255 MiB)
```
2. It seems to be more correct (in this specific case its `Base.parse` being shadowed by `JSON.Parsers.parse`, which is imported into `JSON` with `using .Parsers: parse`):
```
julia> :parse in all_names(JSON)
true

julia> a, b = SymbolServer.split_module_names(JSON, allns);

julia> :parse in a || :parse in b
false
```

This is only a very superficial integration of that function, mostly because I'm not 100% confident I haven't missed anything and would like to hear @ZacLN's opinion on this approach first :)

@timholy might also be interested in this, given his recent work on performance.