### PR TITLE
make sure `_doc` always returns a String

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -198,7 +198,7 @@ function _doc(@nospecialize(object))
         sig = Union{}
         if Base.Docs.defined(binding)
             result = Base.Docs.getdoc(Base.Docs.resolve(binding), sig)
-            result === nothing || return result
+            result === nothing || return string(result)
         end
         results, groups = Base.Docs.DocStr[], Base.Docs.MultiDoc[]
     # Lookup `binding` and `sig` for matches in all modules of the docsystem.


### PR DESCRIPTION
Should fix a 
```
ERROR: LoadError: MethodError: Cannot `convert` an object of type Text{String} to an object of type String
Closest candidates are:
  convert(::Type{String}, !Matched::CategoricalArrays.CategoricalValue) at C:\Users\...\.julia\packages\CategoricalArrays\0ZAbp\src\value.jl:60
  convert(::Type{String}, !Matched::FilePathsBase.AbstractPath) at C:\Users\...\.julia\packages\FilePathsBase\9nTwN\src\path.jl:112
  convert(::Type{String}, !Matched::LibPQ.PQValue) at C:\Users\...\.julia\packages\LibPQ\LSA5x\src\parsing.jl:105
  ...
Stacktrace:
 [1] Main.SymbolServer.FunctionStore(::Main.SymbolServer.VarRef, ::Array{Main.SymbolServer.MethodStore,1}, ::Text{String}, ::Main.SymbolServer.VarRef, ::Bool) at c:\Users\...\.vscode-insiders\extensions\julialang.language-julia-insider-1.0.10\scripts\packages\SymbolServer\src\symbols.jl:76
 [2] Main.SymbolServer.FunctionStore(::Any, ::Module, ::Bool) at c:\Users\...\.vscode-insiders\extensions\julialang.language-julia-insider-1.0.10\scripts\packages\SymbolServer\src\symbols.jl:87
 [3] symbols(::Dict{Symbol,Main.SymbolServer.ModuleStore}, ::Module, ::Base.IdSet{Symbol}, ::Base.IdSet{Module}) at c:\Users\...\.vscode-insiders\extensions\julialang.language-julia-insider-1.0.10\scripts\packages\SymbolServer\src\symbols.jl:402
 [4] symbols(::Dict{Symbol,Main.SymbolServer.ModuleStore}, ::Nothing, ::Base.IdSet{Symbol}, ::Base.IdSet{Module}) at c:\Users\...\.vscode-insiders\extensions\julialang.language-julia-insider-1.0.10\scripts\packages\SymbolServer\src\symbols.jl:433
 [5] top-level scope at c:\Users\...\.vscode-insiders\extensions\julialang.language-julia-insider-1.0.10\scripts\packages\SymbolServer\src\server.jl:148
 [6] include(::Function, ::Module, ::String) at .\Base.jl:380
 [7] include(::Module, ::String) at .\Base.jl:368
 [8] exec_options(::Base.JLOptions) at .\client.jl:296
 [9] _start() at .\client.jl:506
```
error we got on Azure.