### PR TITLE
add recursive_copy method

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -356,6 +356,8 @@ recursive_copy(::Nothing) = nothing
 
 recursive_copy(s::Symbol) = s
 
+recursive_copy(c::Char) = c
+
 recursive_copy(str::String) = str
 
 recursive_copy(x::Number) = x


### PR DESCRIPTION
Add's a missing recursive_copy method. Could possibly add a fallback method that masks `deepcopy`?