### PR TITLE
Fix a typo

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,7 +132,7 @@ else
     is_package_deved(manifest, uuid) = manifest[uuid].path !== nothing
 end
 
-function sha2_256_dir(path, sha=sha = zeros(UInt8, 32))
+function sha2_256_dir(path, sha=zeros(UInt8, 32))
     (uperm(path) & 0x04) != 0x04 && return
     startswith(path, ".") && return
     if isfile(path) && endswith(path, ".jl")


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/crashreporting-issues/issues/27.

At least I think it does? I would have expected the old version of the code to actually be a syntax error?

For every PR, please check the following:
- [X] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [X] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
