### PR TITLE
turn on get_return_types in indexpackage.jl

### DIFF
--- a/src/indexpackage.jl
+++ b/src/indexpackage.jl
@@ -49,7 +49,7 @@ end
 
 # Get the symbols
 env = getenvtree([current_package_name])
-symbols(env, m)
+symbols(env, m, get_return_type=true)
 
  # Strip out paths
 modify_dirs(env[current_package_name], f -> modify_dir(f, pkg_src_dir(Base.loaded_modules[Base.PkgId(current_package_uuid, string(current_package_name))]), "PLACEHOLDER"))


### PR DESCRIPTION
Runs inference on all methods when we're caching them (costly)

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
