### PR TITLE
Handle boo return from env_project_file

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -528,6 +528,7 @@ Find out where a package is installed without having to load it.
 """
 function get_pkg_path(pkg::Base.PkgId, env, depot_path)
     project_file = Base.env_project_file(env)
+    project_file isa Bool && return nothing
     manifest_file = Base.project_file_manifest_path(project_file)
 
     d = Base.parsed_toml(manifest_file)


### PR DESCRIPTION
Hopefully fixes a bug from crash reporting. We generally need to handle `Bool` return values from `env_project_file`, not sure what I did here is the right behavior, though...

@ZacLN can you review, I think you originally wrote this code.