### PR TITLE
make `read_manifest` slightly more robust

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,7 @@ If the file can't be read, return `nothing`.
 function read_manifest(manifest_filename)
     try
         m = Pkg.API.read_manifest(manifest_filename)
-        if VERSION < v"1.6.2"
+        if m isa Dict
             return m
         else
             return m.deps


### PR DESCRIPTION
Fixes issue linked to https://github.com/julia-vscode/SymbolServer.jl/pull/229

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
