### PR TITLE
fix read_manifest

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,12 +32,8 @@ function read_manifest(manifest_filename)
             return m.deps
         end
     catch err
-        if err isa Pkg.Types.PkgError
-            @warn "Could not load manifest."
-            return nothing
-        else
-            rethrow(err)
-        end
+        @warn "Could not load manifest." exception=(err, catch_backtrace())
+        return nothing
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/crashreporting-issues/issues/41.
Fixes https://github.com/julia-vscode/crashreporting-issues/issues/42.

We don't care about any errors in that call to `Pkg.API.read_manifest` -- there's nothing we can do about them and no way to recover from them more gracefully.