### PR TITLE
Speed up deserialization, improve progress reporting, add yield point

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -86,8 +86,8 @@ for (pk_name, uuid) in toplevel_pkgs
 end
 
 # Load all packages together
-for uuid in packages_to_load
-    load_package(ctx, uuid, conn, LoadingBay)
+for (i, uuid) in enumerate(packages_to_load)
+    load_package(ctx, uuid, conn, LoadingBay, round(Int, 100*(i - 1)/length(packages_to_load)))
 end
 
 # Create image of whole package env. This creates the module structure only.
@@ -118,5 +118,8 @@ end
 write_depot(server, server.context, written_caches)
 
 @info "Symbol server indexing took $((time_ns() - start_time) / 1e9) seconds."
+
+println(conn, "DONE")
+close(conn)
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -554,18 +554,18 @@ function get_pkg_path(pkg::Base.PkgId, env, depot_path)
     return nothing
 end
 
-function load_package(c::Pkg.Types.Context, uuid, conn, loadingbay)
+function load_package(c::Pkg.Types.Context, uuid, conn, loadingbay, percentage = missing)
     isinmanifest(c, uuid isa String ? Base.UUID(uuid) : uuid) || return
     pe_name = packagename(c, uuid)
 
     pid = Base.PkgId(uuid isa String ? Base.UUID(uuid) : uuid, pe_name)
     if pid in keys(Base.loaded_modules)
-        conn !== nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion")
+        conn !== nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion;$percentage")
         loadingbay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
         m = getfield(loadingbay, Symbol(pe_name))
     else
         m = try
-            conn !== nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion")
+            conn !== nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion;$percentage")
             loadingbay.eval(:(import $(Symbol(pe_name))))
             conn !== nothing && println(conn, "STOPLOAD;$pe_name")
             m = getfield(loadingbay, Symbol(pe_name))


### PR DESCRIPTION
This makes sure that task switches can happen during deserialization, so the LS doesn't appear unresponsive. It also speeds up deserialization by a factor of 10 to 20 for e.g. CUDA.jl. Lastly, progress reporting now includes a rough percentage and more info as to what's actually going on (instead of the generic "indexing packages...").