### PR TITLE
Fix missing docs for some symbols

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -16,7 +16,7 @@ struct ModuleStore <: SymStore
     used_modules::Vector{Symbol}
 end
 
-ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), _doc(m), true, unsorted_names(m), Symbol[])
+ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), _doc(Base.Docs.Binding(m, nameof(m))), true, unsorted_names(m), Symbol[])
 Base.getindex(m::ModuleStore, k) = m.vals[k]
 Base.setindex!(m::ModuleStore, v, k) = (m.vals[k] = v)
 Base.haskey(m::ModuleStore, k) = haskey(m.vals, k)
@@ -482,7 +482,7 @@ function load_core(; get_return_type = false)
     end
 
     cache[:Base][Symbol("@.")] = cache[:Base][Symbol("@__dot__")]
-    cache[:Core][:Main] = GenericStore(VarRef(nothing, :Main), FakeTypeName(Module), _doc(Main), true)
+    cache[:Core][:Main] = GenericStore(VarRef(nothing, :Main), FakeTypeName(Module), _doc(Base.Docs.Binding(Main, :Main)), true)
     # Add built-ins
     builtins = Symbol[nameof(getfield(Core, n).instance) for n in unsorted_names(Core, all = true) if isdefined(Core, n) && getfield(Core, n) isa DataType && isdefined(getfield(Core, n), :instance) && getfield(Core, n).instance isa Core.Builtin]
     cnames = unsorted_names(Core)

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -16,7 +16,7 @@ struct ModuleStore <: SymStore
     used_modules::Vector{Symbol}
 end
 
-ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), "", true, unsorted_names(m), Symbol[])
+ModuleStore(m) = ModuleStore(VarRef(m), Dict{Symbol,Any}(), _doc(m), true, unsorted_names(m), Symbol[])
 Base.getindex(m::ModuleStore, k) = m.vals[k]
 Base.setindex!(m::ModuleStore, v, k) = (m.vals[k] = v)
 Base.haskey(m::ModuleStore, k) = haskey(m.vals, k)

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -455,7 +455,7 @@ function symbols(env::EnvStore, m::Union{Module,Nothing} = nothing, allnames::Ba
                     cache[s] = VarRef(x)
                 end
             else
-                cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(x), s in getnames(m))
+                cache[s] = GenericStore(VarRef(VarRef(m), s), FakeTypeName(typeof(x)), _doc(Base.Docs.Binding(m, s)), s in getnames(m))
             end
         end
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -179,11 +179,18 @@ function sha_pkg(pe::PackageEntry)
     path(pe) isa String && isdir(path(pe)) && isdir(joinpath(path(pe), "src")) ? sha2_256_dir(joinpath(path(pe), "src")) : nothing
 end
 
-_doc(object::UnionAll) = _doc(Base.unwrap_unionall(object))
 function _doc(@nospecialize(object))
+    local binding
     try
         binding = Base.Docs.aliasof(object, typeof(object))
         !(binding isa Base.Docs.Binding) && return ""
+    catch
+        return ""
+    end
+    return _doc(binding)
+end
+function _doc(binding::Base.Docs.Binding)
+    try
         sig = Union{}
         if Base.Docs.defined(binding)
             result = Base.Docs.getdoc(Base.Docs.resolve(binding), sig)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -179,16 +179,6 @@ function sha_pkg(pe::PackageEntry)
     path(pe) isa String && isdir(path(pe)) && isdir(joinpath(path(pe), "src")) ? sha2_256_dir(joinpath(path(pe), "src")) : nothing
 end
 
-function _doc(@nospecialize(object))
-    local binding
-    try
-        binding = Base.Docs.aliasof(object, typeof(object))
-        !(binding isa Base.Docs.Binding) && return ""
-    catch
-        return ""
-    end
-    return _doc(binding)
-end
 function _doc(binding::Base.Docs.Binding)
     try
         sig = Union{}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -179,6 +179,7 @@ function sha_pkg(pe::PackageEntry)
     path(pe) isa String && isdir(path(pe)) && isdir(joinpath(path(pe), "src")) ? sha2_256_dir(joinpath(path(pe), "src")) : nothing
 end
 
+_doc(object::UnionAll) = _doc(Base.unwrap_unionall(object))
 function _doc(@nospecialize(object))
     try
         binding = Base.Docs.aliasof(object, typeof(object))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,7 @@ end
         @test !isempty(SymbolServer.stdlibs[:Base][:Libc].doc)         # Module
         @test !isempty(SymbolServer.stdlibs[:Base][:LinRange].doc)     # UnionAll
         @test !isempty(SymbolServer.stdlibs[:Base][:VecOrMat].doc)     # Union
-        @test contains(SymbolServer.stdlibs[:Base][:Cint].doc, "Cint") # Alias
+        @test occursin("Cint", SymbolServer.stdlibs[:Base][:Cint].doc) # Alias
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,10 +89,6 @@ end
         end
     end
 
-    @testset "UnionAll documentation" begin
-        @test !isempty(SymbolServer.stdlibs[:Base][:LinRange].doc)
-    end
-
     mktempdir() do path
         cp(joinpath(@__DIR__, "testenv", "Project.toml"), joinpath(path, "Project.toml"))
         cp(joinpath(@__DIR__, "testenv", "Manifest.toml"), joinpath(path, "Manifest.toml"))
@@ -137,6 +133,15 @@ end
     end
 
     @test SymbolServer.stdlibs[:Base][:Sort][:sort] isa SymbolServer.FunctionStore
+
+    @testset "symbol documentation" begin
+        @test !isempty(SymbolServer.stdlibs[:Base][:abs].doc)          # Function
+        @test !isempty(SymbolServer.stdlibs[:Base][:Pair].doc)         # DataType
+        @test !isempty(SymbolServer.stdlibs[:Base][:Libc].doc)         # Module
+        @test !isempty(SymbolServer.stdlibs[:Base][:LinRange].doc)     # UnionAll
+        @test !isempty(SymbolServer.stdlibs[:Base][:VecOrMat].doc)     # Union
+        @test contains(SymbolServer.stdlibs[:Base][:Cint].doc, "Cint") # Alias
+    end
 end
 
 using SymbolServer: FakeTypeName

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,9 +85,12 @@ end
             x = getfield(Base, n)
             if x isa UnionAll && Base.unwrap_unionall(x) isa DataType && parentmodule(Base.unwrap_unionall(x)) == Base
                 @test SymbolServer.stdlibs[:Base][n] isa SymbolServer.DataTypeStore
-                @test SymbolServer.stdlibs[:Base][n].doc != ""
             end
         end
+    end
+
+    @testset "UnionAll documentation" begin
+        @test !isempty(SymbolServer.stdlibs[:Base][:LinRange].doc)
     end
 
     mktempdir() do path

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,7 @@ end
             x = getfield(Base, n)
             if x isa UnionAll && Base.unwrap_unionall(x) isa DataType && parentmodule(Base.unwrap_unionall(x)) == Base
                 @test SymbolServer.stdlibs[:Base][n] isa SymbolServer.DataTypeStore
+                @test SymbolServer.stdlibs[:Base][n].doc != ""
             end
         end
     end


### PR DESCRIPTION
This adds documentation for UnionAlls, Union types, and Modules. Also, aliases will have documentation that is associated with them and not from of whatever they are aliasing.

Fixes https://github.com/julia-vscode/julia-vscode/issues/2564.
