### PR TITLE
Symbol caches: Larger download batching. Don't ask for non-General pkgs

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -105,8 +105,8 @@ function getstore(ssi::SymbolServerInstance, environment_path::AbstractString, p
                         if !isempty(to_download)
                             n_done = 0
                             n_total = length(to_download)
-                            @sync for batch in Iterators.partition(to_download, 100) # 100 connections at a time
-                                for pkg in batch
+                            for batch in Iterators.partition(to_download, 100) # 100 connections at a time
+                                @sync for pkg in batch
                                     @async begin
                                         yield()
                                         uuid = packageuuid(pkg)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -143,7 +143,7 @@ else
     packageuuid(pkg::Pair{String,UUID}) = last(pkg)
     packageuuid(pkg::Pair{UUID,PackageEntry}) = first(pkg)
 
-    packagename(pkg::Pair{UUID,PackageEntry})::String = last(pkg).name
+    packagename(pkg::Pair{UUID,PackageEntry})::Union{Nothing,String} = last(pkg).name
     packagename(c::Pkg.Types.Context, uuid::UUID) = manifest(c)[uuid].name
     packagename(manifest::Dict{UUID,PackageEntry}, uuid::UUID) = manifest[uuid].name
 
@@ -162,7 +162,8 @@ else
     version(pe::Pair{UUID,PackageEntry}) = last(pe).version
     frommanifest(c::Pkg.Types.Context, uuid) = manifest(c)[uuid]
     frommanifest(manifest::Dict{UUID,PackageEntry}, uuid) = manifest[uuid]
-    tree_hash(pe::PackageEntry) = VERSION >= v"1.3" ? pe.tree_hash : get(pe.other, "git-tree-sha1", nothing)
+    tree_hash(pkg::Pair{UUID,PackageEntry}) = tree_hash(last(pkg))
+    tree_hash(pe::PackageEntry) = VERSION >= v"1.3" ? pe.tree_hash : (pe.other === nothing ? nothing : get(pe.other, "git-tree-sha1", nothing))
 
     is_package_deved(manifest, uuid) = manifest[uuid].path !== nothing
 end


### PR DESCRIPTION
Given non-General packages don't have symbol caches, don't request them, to avoid requesting URLs that include the UUID & name of private packages.

Also the download batching didn't make sense to me. It seems better to limit the concurrent number of downloads, rather than the total number of batches. Update: Now batches of 100

Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
