### PR TITLE
detects rare cache corruption issue and allows SymbolServer to recalculate

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -183,6 +183,7 @@ function cache_methods(@nospecialize(f), name, env, get_return_type)
         # Get inferred method return type
         if get_return_type
             sparams = Core.svec(sparam_syms(m[3])...)
+            rt = try 
             rt = try
                 @static if isdefined(Core.Compiler, :NativeInterpreter)
                 Core.Compiler.typeinf_type(Core.Compiler.NativeInterpreter(), m[3], m[3].sig, sparams)

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -52,7 +52,7 @@ struct DataTypeStore <: SymStore
     exported::Bool
     function DataTypeStore(names, super, parameters, types, fieldnames, methods, doc, exported)
         if length(types) < length(fieldnames)
-            error("Only $(length(types)) types were loaded for $(length(fieldnames)) fieldnames. SymbolServer may recalculate the cache. $(Base.@locals)")
+            error("Only $(length(types)) types were loaded for $(length(fieldnames)) fieldnames. SymbolServer may recalculate the cache.")
         end
         new(names, super, parameters, types, fieldnames, methods, doc, exported)
     end
@@ -183,7 +183,7 @@ function cache_methods(@nospecialize(f), name, env, get_return_type)
         # Get inferred method return type
         if get_return_type
             sparams = Core.svec(sparam_syms(m[3])...)
-            rt = try 
+            rt = try
             rt = try
                 @static if isdefined(Core.Compiler, :NativeInterpreter)
                 Core.Compiler.typeinf_type(Core.Compiler.NativeInterpreter(), m[3], m[3].sig, sparams)

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -184,12 +184,11 @@ function cache_methods(@nospecialize(f), name, env, get_return_type)
         if get_return_type
             sparams = Core.svec(sparam_syms(m[3])...)
             rt = try
-            rt = try
                 @static if isdefined(Core.Compiler, :NativeInterpreter)
-                Core.Compiler.typeinf_type(Core.Compiler.NativeInterpreter(), m[3], m[3].sig, sparams)
-            else
-                Core.Compiler.typeinf_type(m[3], m[3].sig, sparams, Core.Compiler.Params(world))
-            end
+                    Core.Compiler.typeinf_type(Core.Compiler.NativeInterpreter(), m[3], m[3].sig, sparams)
+                else
+                    Core.Compiler.typeinf_type(m[3], m[3].sig, sparams, Core.Compiler.Params(world))
+                end
             catch e
                 Any
             end

--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -50,6 +50,12 @@ struct DataTypeStore <: SymStore
     methods::Vector{MethodStore}
     doc::String
     exported::Bool
+    function DataTypeStore(names, super, parameters, types, fieldnames, methods, doc, exported)
+        if length(types) < length(fieldnames)
+            error("Only $(length(types)) types were loaded for $(length(fieldnames)) fieldnames. SymbolServer may recalculate the cache. $(Base.@locals)")
+        end
+        new(names, super, parameters, types, fieldnames, methods, doc, exported)
+    end
 end
 
 function DataTypeStore(@nospecialize(t), symbol, parent_mod, exported)
@@ -177,7 +183,7 @@ function cache_methods(@nospecialize(f), name, env, get_return_type)
         # Get inferred method return type
         if get_return_type
             sparams = Core.svec(sparam_syms(m[3])...)
-            rt = try 
+            rt = try
                 @static if isdefined(Core.Compiler, :NativeInterpreter)
                 Core.Compiler.typeinf_type(Core.Compiler.NativeInterpreter(), m[3], m[3].sig, sparams)
             else


### PR DESCRIPTION
The corruption is reproducible in my setup, unfortunately I don't have a MWE. But I have a stack trace:
```
ERROR: BoundsError: attempt to access 0-element Vector{Any} at index [1]

Stacktrace:

  [1] getindex

    @ .\array.jl:924 [inlined]

  [2] resolve_getfield(x::CSTParser.EXPR, parent::SymbolServer.DataTypeStore, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\references.jl:273

  [3] resolve_getfield(x::CSTParser.EXPR, b::StaticLint.Binding, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\references.jl:226

  [4] resolve_getfield(x::CSTParser.EXPR, scope::StaticLint.Scope, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\references.jl:193

  [5] resolve_ref(x::CSTParser.EXPR, scope::StaticLint.Scope, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\references.jl:51

  [6] resolve_ref(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\references.jl:23

  [7] (::StaticLint.Delayed)(x::CSTParser.EXPR)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:116

  [8] traverse(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:225

  [9] (::StaticLint.Delayed)(x::CSTParser.EXPR)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:119

 [10] traverse(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:225

 [11] (::StaticLint.Delayed)(x::CSTParser.EXPR)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:119

 [12] traverse(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:225

 [13] (::StaticLint.Delayed)(x::CSTParser.EXPR)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:119

 [14] traverse(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:225

 [15] (::StaticLint.Delayed)(x::CSTParser.EXPR)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:119

 [16] traverse(x::CSTParser.EXPR, state::StaticLint.Delayed)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:225

 [17] semantic_pass(file::LanguageServer.Document, modified_expr::Nothing)

    @ StaticLint c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:177

 [18] semantic_pass

    @ c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\StaticLint\src\StaticLint.jl:170 [inlined]

 [19] relintserver(server::LanguageServerInstance)

    @ LanguageServer c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\LanguageServer\src\languageserverinstance.jl:427

 [20] run(server::LanguageServerInstance)

    @ LanguageServer c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\packages\LanguageServer\src\languageserverinstance.jl:407

 [21] top-level scope

    @ c:\Users\kirby\MyDrive\Documents\julia-vscode\scripts\languageserver\main.jl:101

 [22] include(mod::Module, _path::String)

    @ Base .\Base.jl:419

 [23] exec_options(opts::Base.JLOptions)

    @ Base .\client.jl:303

 [24] _start()

    @ Base .\client.jl:522
```

StaticLint/src/references.jl:273 assumes **DataTypeStore.types** has equal (or greater) length as **DataTypeStore.fieldnames**. This fix just asserts this assumption and throws an error if not met, which SymbolServer will catch and recache the file. It was successful after one recalculation and the error will no longer occur on this symbol store. 
