### PR TITLE
Accept Module in FakeTypeName

### DIFF
--- a/src/faketypes.jl
+++ b/src/faketypes.jl
@@ -39,7 +39,7 @@ function FakeTypeName(@nospecialize(x); justname=false)
         FakeTypeVar(x)
     elseif x isa Core.TypeofBottom
         FakeTypeofBottom()
-    elseif x isa Module && justname
+    elseif x isa Module
         VarRef(x)
     else
         error((x, typeof(x)))

--- a/src/faketypes.jl
+++ b/src/faketypes.jl
@@ -39,6 +39,8 @@ function FakeTypeName(@nospecialize(x); justname=false)
         FakeTypeVar(x)
     elseif x isa Core.TypeofBottom
         FakeTypeofBottom()
+    elseif x isa Module && justname
+        VarRef(x)
     else
         error((x, typeof(x)))
     end


### PR DESCRIPTION
Fix the VSCode extension on julia master.

I just updated julia and the extension crashed with the following stacktrace:

<details>

<summary>Stacktrace</summary>

```
ERROR: LoadError: (Core, Module)
Stacktrace:
  [1] error(s::Tuple{Module, DataType})
    @ Base ./error.jl:44
  [2] SymbolServer.FakeTypeName(x::Any; justname::Bool)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/faketypes.jl:43
  [3] _parameter(p::Any)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/faketypes.jl:73
  [4] SymbolServer.FakeTypeName(x::Any; justname::Bool)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/faketypes.jl:30
  [5] FakeTypeName
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/faketypes.jl:17 [inlined]
  [6] symbols(env::Dict{Symbol, SymbolServer.ModuleStore}, m::Module, allnames::Base.IdSet{Symbol}, visited::Base.IdSet{Module}; get_return_type::Bool)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:479
  [7] symbols
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:419 [inlined]
  [8] symbols(env::Dict{Symbol, SymbolServer.ModuleStore}, m::Nothing, allnames::Base.IdSet{Symbol}, visited::Base.IdSet{Module}; get_return_type::Bool)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:484
  [9] symbols (repeats 4 times)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:419 [inlined]
 [10] load_core(; get_return_type::Bool)
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:493
 [11] load_core()
    @ SymbolServer ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/symbols.jl:490
 [12] top-level scope
    @ ~/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/SymbolServer.jl:361
 [13] include
    @ Base ./Base.jl:523 [inlined]
 [14] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:2311
 [15] top-level scope
    @ stdin:3
in expression starting at /home/liozou/.vscode/extensions/julialang.language-julia-1.54.2/scripts/packages/SymbolServer/src/SymbolServer.jl:1
in expression starting at stdin:3
ERROR: Failed to precompile SymbolServer [cf896787-08d5-524d-9de7-132aaa0cb996] to "/home/liozou/.julia/compiled/v1.11/SymbolServer/jl_3jBxup".
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, keep_loaded_modules::Bool)
    @ Base ./loading.jl:2563
  [3] compilecache
    @ Base ./loading.jl:2429 [inlined]
  [4] (::Base.var"#1027#1028"{Base.PkgId})()
    @ Base ./loading.jl:2031
  [5] mkpidlock(f::Base.var"#1027#1028"{Base.PkgId}, at::String, pid::Int32; kwopts::@Kwargs{stale_age::Int64, wait::Bool})
    @ FileWatching.Pidfile ~/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:94
  [6] #mkpidlock#6
    @ FileWatching.Pidfile ~/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:89 [inlined]
  [7] trymkpidlock(::Function, ::Vararg{Any}; kwargs::@Kwargs{stale_age::Int64})
    @ FileWatching.Pidfile ~/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:112
  [8] #invokelatest#2
    @ Base ./essentials.jl:931 [inlined]
  [9] invokelatest
    @ Base ./essentials.jl:926 [inlined]
 [10] maybe_cachefile_lock(f::Base.var"#1027#1028"{Base.PkgId}, pkg::Base.PkgId, srcpath::String; stale_age::Int64)
    @ Base ./loading.jl:3135
 [11] maybe_cachefile_lock
    @ Base ./loading.jl:3132 [inlined]
 [12] _require(pkg::Base.PkgId, env::String)
    @ Base ./loading.jl:2027
 [13] __require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1872
 [14] #invoke_in_world#3
    @ Base ./essentials.jl:963 [inlined]
 [15] invoke_in_world
    @ Base ./essentials.jl:960 [inlined]
 [16] _require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1863
 [17] macro expansion
    @ Base ./loading.jl:1801 [inlined]
 [18] macro expansion
    @ Base ./lock.jl:267 [inlined]
 [19] __require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1762
 [20] #invoke_in_world#3
    @ Base ./essentials.jl:963 [inlined]
 [21] invoke_in_world
    @ Base ./essentials.jl:960 [inlined]
 [22] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1755
```
</details>

Looking into it, this package fails to precompile because the `FakeTypeName` constructor is given a value `Core.AddrSpace{Core}`, which thus has `Core` as a parameter, which ends up going back to `FakeTypeName` again but `FakeTypeName` does not accept a `Module` input and ends up erroring.

I don't know this code at all, but this PR patches the issue for me so I thought I'd submit it (along with the bug report).