### PR TITLE
Fix UndefVarError for PkgEntry

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -3,6 +3,7 @@ module SymbolServer
 export SymbolServerInstance, getstore
 
 using Pkg, SHA
+using Pkg.Registry: PkgEntry
 using Base: UUID, Process
 import Sockets, UUIDs
 


### PR DESCRIPTION
Fixes #294.

The language server showed this log:

```
┌ Error: Symbol cache downloading: Failed to identify which packages to omit based on the General registry.
│ All packages will be processsed locally
│   err =
│    UndefVarError: `PkgEntry` not defined in `SymbolServer`
│    Suggestion: check for spelling errors or missing imports.
└ @ SymbolServer 
```

This UndefVarError lead to always erroring on the side of caution as mentioned here:

https://github.com/julia-vscode/SymbolServer.jl/blob/2201c26a43013a7bf71b4829ee4967e072070cab/src/SymbolServer.jl#L114-L122
