### PR TITLE
[v1.12] loading bay detected access prior to definition

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -628,13 +628,13 @@ function load_package(c::Pkg.Types.Context, uuid, conn, loadingbay, percentage =
     if pid in keys(Base.loaded_modules)
         conn !== nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion;$percentage")
         loadingbay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
-        m = getfield(loadingbay, Symbol(pe_name))
+        m = invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
     else
         m = try
             conn !== nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion;$percentage")
             loadingbay.eval(:(import $(Symbol(pe_name))))
             conn !== nothing && println(conn, "STOPLOAD;$pe_name")
-            m = getfield(loadingbay, Symbol(pe_name))
+            m = invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
         catch
             return
         end


### PR DESCRIPTION
Running the LSP with julia v1.12 can lead to package
access prior to their definition, and sometimes crashes.

We can use `invokelateset` in `load_package` to fix the issue.

For example:
```log
[ Info: Starting LS with Julia 1.12.0-rc1
  Activating project at `~/.vscode-insiders/extensions/julialang.language-julia-1.152.1/scripts/environments/languageserver/v1.12`
[ Info: Starting the Julia Language Server
[ Info: Symbol server store is at '/home/quachpas/.config/Code - Insiders/User/globalStorage/julialang.language-julia/symbolstorev5'.
[ Info: Starting LS at 1755614918
[ Info: Will cache package StaticArrays (90137ffa-7385-5640-81b9-e52037218182)
[ Info: Will cache package Nemo (2edaba10-b0f1-5616-af89-8c11ac63239a)
[ Info: Will cache package JLD2 (033835bb-8acc-5ee8-8aae-3f567f8a3819)
[ Info: Will cache package PrecompileTools (aea7be01-6a6a-4083-8856-8a6e6704d82a)
[ Info: Will cache package LinearAlgebra (37e2e46d-f89d-539d-b4ee-838fcccc9c8e)
[ Info: Will cache package Logging (56ddb016-857b-54e1-b83d-db4d58db5568)
[ Info: Will cache package ProgressMeter (92933f4c-e287-5a05-a399-4b506db050ca)
WARNING: Detected access to binding `LoadingBay.StaticArrays` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `LoadingBay.Nemo` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `LoadingBay.JLD2` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
ERROR: LoadError: [ Info: Indexing StaticArrays...
[ Info: Indexing Nemo...
[ Info: Indexing JLD2...
[ Info: Processing PrecompileTools...
UndefVarError: `PrecompileTools` not defined in `Main.SymbolServer.LoadingBay`
The binding may be too new: running in world age 39016, while current world is 39043.
Hint: PrecompileTools is loaded but not imported in the active module Main.
Stacktrace:
 [1] load_package(c::Pkg.Types.Context, uuid::Base.UUID, conn::Base.PipeEndpoint, loadingbay::Module, percentage::Int64)
   @ Main.SymbolServer ~/.vscode-insiders/extensions/julialang.language-julia-1.152.1/scripts/packages/SymbolServer/src/utils.jl:632
 [2] top-level scope
   @ ~/.vscode-insiders/extensions/julialang.language-julia-1.152.1/scripts/packages/SymbolServer/src/server.jl:100
 [3] include(mod::Module, _path::String)
   @ Base ./Base.jl:303
 [4] exec_options(opts::Base.JLOptions)
   @ Base ./client.jl:321
 [5] _start()
   @ Base ./client.jl:554
in expression starting at /home/quachpas/.vscode-insiders/extensions/julialang.language-julia-1.152.1/scripts/packages/SymbolServer/src/server.jl:1
```

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
