### PR TITLE
fix: don't depend on PkgEntry for empty dicts in get_general_pkgs

### DIFF
--- a/src/SymbolServer.jl
+++ b/src/SymbolServer.jl
@@ -43,7 +43,7 @@ function get_general_pkgs()
         @static if VERSION >= v"1.7-"
             regs = Pkg.Types.Context().registries
             i = findfirst(r -> r.name == "General" && r.uuid == GENERAL_REGISTRY_UUID, regs)
-            i === nothing && return Dict{UUID, PkgEntry}()
+            i === nothing && return Dict()
             return regs[i].pkgs
         else
             for r in Pkg.Types.collect_registries()
@@ -51,7 +51,7 @@ function get_general_pkgs()
                 reg = Pkg.Types.read_registry(joinpath(r.path, "Registry.toml"))
                 return reg["packages"]
             end
-            return Dict{UUID, PkgEntry}()
+            return Dict()
         end
     finally
         append!(empty!(Base.DEPOT_PATH), dp_before)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -628,13 +628,13 @@ function load_package(c::Pkg.Types.Context, uuid, conn, loadingbay, percentage =
     if pid in keys(Base.loaded_modules)
         conn !== nothing && println(conn, "PROCESSPKG;$pe_name;$uuid;noversion;$percentage")
         loadingbay.eval(:($(Symbol(pe_name)) = $(Base.loaded_modules[pid])))
-        m = invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
+        m = Base.invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
     else
         m = try
             conn !== nothing && println(conn, "STARTLOAD;$pe_name;$uuid;noversion;$percentage")
             loadingbay.eval(:(import $(Symbol(pe_name))))
             conn !== nothing && println(conn, "STOPLOAD;$pe_name")
-            m = invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
+            m = Base.invokelatest(() -> getfield(loadingbay, Symbol(pe_name)))
         catch
             return
         end


### PR DESCRIPTION
Supercedes https://github.com/julia-vscode/SymbolServer.jl/pull/296/.
Hopefully fixes https://github.com/julia-vscode/SymbolServer.jl/issues/294.