### PR TITLE
feat: change symstore structure

### DIFF
--- a/registryindexer/main.jl
+++ b/registryindexer/main.jl
@@ -28,7 +28,7 @@ function get_all_package_versions(;max_versions=typemax(Int))
         }) |>
         @mutate(
             versions = (Pkg.TOML.parsefile(joinpath(registry_folder_path, _.path, "Versions.toml")) |>
-                @map(i->{version=VersionNumber(i[1]), treehash=i[2]["git-tree-sha1"]}) |> 
+                @map(i->{version=VersionNumber(i[1]), treehash=i[2]["git-tree-sha1"]}) |>
                 @orderby_descending(i->i.version) |>
                 @take(max_versions) |>
                 collect)
@@ -120,9 +120,9 @@ true || asyncmap(julia_versions) do v
             #     error_filename = "v$(versionwithoutplus)_$(v.treehash).unavailable"
 
             #     # Write them to a file
-            #     open(joinpath(path, error_filename), "w") do io                    
+            #     open(joinpath(path, error_filename), "w") do io
             #     end
-            
+
             #     Pkg.PlatformEngines.package(path, cache_path)
             # end
 
@@ -157,7 +157,7 @@ end
 unindexed_packageversions = Iterators.take(filter(flattened_packageversions) do v
     versionwithoutplus = replace(string(v.version), '+'=>'_')
 
-    cache_path = joinpath(cache_folder, "v1", "packages", string(uppercase(v.name[1])), "$(v.name)_$(v.uuid)", "v$(versionwithoutplus)_$(v.treehash).tar.gz")
+    cache_path = joinpath(cache_folder, "v2", "packages", string(uppercase(v.name[1])), v.name, string(v.uuid), "$(v.treehash).tar.gz")
 
     return !isfile(cache_path)
 end, max_n)
@@ -177,9 +177,9 @@ count_successfully_cached = 0
 asyncmap(unindexed_packageversions, ntasks=max_tasks) do v
     versionwithoutplus = replace(string(v.version), '+'=>'_')
 
-    cache_path = joinpath(cache_folder, "v1", "packages", string(uppercase(v.name[1])), "$(v.name)_$(v.uuid)")
+    cache_path = joinpath(cache_folder, "v2", "packages", string(uppercase(v.name[1])), v.name, string(v.uuid))
     mkpath(cache_path)
-    cache_path_compressed = joinpath(cache_path, "v$(versionwithoutplus)_$(v.treehash).tar.gz")
+    cache_path_compressed = joinpath(cache_path, "$(v.treehash).tar.gz")
 
     mktempdir() do path
         cancel_source = CancellationTokenSource(timeout_per_package)
@@ -218,12 +218,12 @@ asyncmap(unindexed_packageversions, ntasks=max_tasks) do v
             # @info res.stdout
             # @info res.stderr
 
-            error_filename = "v$(versionwithoutplus)_$(v.treehash).unavailable"
+            error_filename = "$(v.treehash).unavailable"
 
             isfile(joinpath(path, error_filename)) && rm(joinpath(path, error_filename))
 
             # Write them to a file
-            open(joinpath(path, error_filename), "w") do io                    
+            open(joinpath(path, error_filename), "w") do io
             end
 
             open(joinpath(cache_folder, "logs", res.code==10 ? "packageloadfailure" : res.code==20 ? "packageinstallfailure" : "packageindexfailure", "log_$(v.name)_v$(versionwithoutplus)_stdout.txt"), "w") do f

--- a/src/indexpackage.jl
+++ b/src/indexpackage.jl
@@ -15,7 +15,11 @@ current_package_treehash = ARGS[4]
 store_path = length(ARGS) >= 5 ? ARGS[5] : "/symcache"
 
 current_package_versionwithoutplus = replace(string(current_package_version), '+'=>'_')
-filename_with_extension = "v$(current_package_versionwithoutplus)_$current_package_treehash.jstore"
+filename = isempty(current_package_treehash) ?
+    string(current_package_versionwithoutplus) :
+    current_package_treehash
+filename_with_extension = "$(filename).jstore"
+cache_file_path = joinpath(store_path, filename_with_extension)
 
 module LoadingBay end
 
@@ -71,7 +75,8 @@ modify_dirs(env[current_package_name], f -> modify_dir(f, pkg_src_dir(Base.loade
 # There's an issue here - @enum used within CSTParser seems to add a method that is introduced from Enums.jl...
 
 # Write them to a file
-open(joinpath(store_path, filename_with_extension), "w") do io
+mkpath(dirname(cache_file_path))
+open(cache_file_path, "w") do io
     CacheStore.write(io, Package(string(current_package_name), env[current_package_name], current_package_uuid, nothing))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -483,7 +483,7 @@ end
 function get_file_from_cloud(manifest, uuid, environment_path, depot_dir, cache_dir="../cache", download_dir="../downloads/", symbolcache_upstream="https://www.julia-vscode.org/symbolcache")
     paths = get_cache_path(manifest, uuid)
     name = packagename(manifest, uuid)
-    link = string(first(splitext(join([symbolcache_upstream, "store/v1/packages", paths...], '/'))), ".tar.gz")
+    link = string(first(splitext(join([symbolcache_upstream, "store/v2/packages", paths...], '/'))), ".tar.gz")
 
     dest_filepath = joinpath(cache_dir, paths...)
     dest_filepath_unavailable = string(first(splitext(dest_filepath)), ".unavailable")
@@ -680,19 +680,20 @@ function get_cache_path(manifest, uuid)
     pkg_info = frommanifest(manifest, uuid)
     ver = version(pkg_info)
     if ver === nothing
-        ver = "nothing"
         if isdefined(Pkg.Types, :is_stdlib) && Pkg.Types.is_stdlib(uuid)
             ver = VERSION
         end
     end
-    ver = replace(string(ver), '+'=>'_')
     th = tree_hash(pkg_info)
-    th = th === nothing ? "nothing" : th
 
-    [
+    filename = something(th, ver, "unknown")
+    filename = replace(string(filename), '+'=>'_')
+
+    return [
         string(uppercase(string(name)[1]))
-        string(name, "_", uuid)
-        string("v", ver, "_", th, ".jstore")
+        string(name)
+        string(uuid)
+        string(filename, ".jstore")
     ]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,7 +201,7 @@ end
 
         # Inspect the cached version, and check that the package SHA has been computed
         # correctly.
-        cache_path = joinpath(store_path, "A", "A_94f385dd-073b-49fe-b7ed-f824d09b3331", "v0.1.0_nothing.jstore")
+        cache_path = joinpath(store_path, "A", "A", "94f385dd-073b-49fe-b7ed-f824d09b3331", "0.1.0.jstore")
         @test isfile(cache_path)
 
         cached_version = open(SymbolServer.CacheStore.read, cache_path)
@@ -434,9 +434,9 @@ end
         @test haskey(store, :B)
 
         # Inspect the on-disk cache file directly.
-        cache_path = joinpath(store_path, "B",
-            "B_b8d7f5ca-4a81-4f4a-b8c7-1f4a0d2b3c4e",
-            "v0.1.0_nothing.jstore")
+        cache_path = joinpath(store_path, "B", "B",
+            "b8d7f5ca-4a81-4f4a-b8c7-1f4a0d2b3c4e",
+            "0.1.0.jstore")
         @test isfile(cache_path)
 
         cached = open(SymbolServer.CacheStore.read, cache_path)
@@ -494,16 +494,17 @@ end
         indexpkg = abspath(joinpath(@__DIR__, "..", "src", "indexpackage.jl"))
 
         # ARGS[1..4] = name, version, uuid, treehash; ARGS[5] = store_path.
-        # treehash is "nothing" (matches the literal string the script writes
-        # into the cache filename when no tree hash is available).
-        cmd = `$jl_cmd --project=$project_path --startup-file=no $indexpkg B 0.1.0 b8d7f5ca-4a81-4f4a-b8c7-1f4a0d2b3c4e nothing $store_path`
+        # Empty treehash exercises the no-treehash fallback: the script names
+        # the cache file after the version instead.
+        treehash = ""
+        cmd = `$jl_cmd --project=$project_path --startup-file=no $indexpkg B 0.1.0 b8d7f5ca-4a81-4f4a-b8c7-1f4a0d2b3c4e $treehash $store_path`
         proc = withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0) do
             run(ignorestatus(cmd))
         end
         # The script intentionally exits 37 on success.
         @test proc.exitcode == 37
 
-        cache_path = joinpath(store_path, "v0.1.0_nothing.jstore")
+        cache_path = joinpath(store_path, "0.1.0.jstore")
         @test isfile(cache_path)
 
         cached = open(SymbolServer.CacheStore.read, cache_path)
@@ -642,9 +643,9 @@ end
     using SymbolServer
 
     mktempdir() do store_path
-        pkg_dir = joinpath(store_path, "Bogus", "Bogus_00000000-0000-0000-0000-000000000000")
+        pkg_dir = joinpath(store_path, "B", "Bogus", "00000000-0000-0000-0000-000000000000")
         mkpath(pkg_dir)
-        cache_path = joinpath(pkg_dir, "v0.1.0_nothing.jstore")
+        cache_path = joinpath(pkg_dir, "0.1.0.jstore")
         open(cache_path, "w") do io
             Base.write(io, UInt8[0xff])    # unknown header → CacheCorruptedError
         end


### PR DESCRIPTION
from `A/Abc_$uuid/v$ver_$treehash.jstore`  to `A/Abc/$uuid/$(treehash|version).jstore` because that seems a bit cleaner.

This is a) basically purely cosmetic and b) requires server side changes too, so I'm not sure it's really worth it. On the other hand, we'll want to bump the cache file format version anyways, so might as well break more stuff.