### PR TITLE
fix: propagate using REPL fix to server.jl and indexpackage.jl

### DIFF
--- a/src/indexpackage.jl
+++ b/src/indexpackage.jl
@@ -3,6 +3,10 @@ module SymbolServer
 using Pkg, SHA
 using Base: UUID
 
+# this is required to get parsedocs to work on Julia 1.11 and newer, since the implementation
+# moved there
+using REPL
+
 current_package_name = Symbol(ARGS[1])
 current_package_version = VersionNumber(ARGS[2])
 current_package_uuid = UUID(ARGS[3])

--- a/src/server.jl
+++ b/src/server.jl
@@ -28,6 +28,10 @@ end
 using Pkg, SHA
 using Base: UUID
 
+# this is required to get parsedocs to work on Julia 1.11 and newer, since the implementation
+# moved there
+using REPL
+
 include("faketypes.jl")
 include("symbols.jl")
 include("utils.jl")


### PR DESCRIPTION
Base.Docs.parsedoc moved to the REPL stdlib in Julia 1.11. PR #288 fixed this in SymbolServer.jl, but the same using REPL was never added to the two standalone scripts that also call _doc(). Without it, parsedoc throws a MethodError that is silently caught, causing all docstrings to be stored as empty strings in the generated .jstore files.

server.jl affects local indexing; indexpackage.jl affects the pre-built cloud cache files.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
